### PR TITLE
Remove explicit check for Subverion 1.7

### DIFF
--- a/comp.php
+++ b/comp.php
@@ -446,13 +446,11 @@ if ($rep) {
 					if ($debug) print 'Skipping: '.$line.'<br />';
 
 					while ($line = trim(fgets($diff))) {
-						if (version_compare($config->getSubversionVersion(), '1.7.0') >= 0) {
-							if (!strncmp($line, 'Index: ', 7)) {
-								break;
-							}
-							if (!strncmp($line, '##', 2) || $line == '\ No newline at end of file') {
-								continue;
-							}
+						if (!strncmp($line, 'Index: ', 7)) {
+							break;
+						}
+						if (!strncmp($line, '##', 2) || $line == '\ No newline at end of file') {
+							continue;
 						}
 						$listing[$index++]['info'] = escape(toOutputEncoding($line));
 						clearVars();


### PR DESCRIPTION
Anything below 1.8 isn't supported anyway by the ASF. We expect users to run 1.7 at least.