### PR TITLE
Remove custom include path

### DIFF
--- a/dl.php
+++ b/dl.php
@@ -26,7 +26,6 @@ require_once 'include/setup.php';
 require_once 'include/svnlook.php';
 require_once 'include/utils.php';
 
-ini_set('include_path', $locwebsvnreal.'/lib/pear'.$config->pathSeparator.ini_get('include_path'));
 @include_once 'Archive/Tar.php';
 
 function setDirectoryTimestamp($dir, $timestamp) {

--- a/include/diff_inc.php
+++ b/include/diff_inc.php
@@ -22,7 +22,6 @@
 //
 // Diff to files
 
-ini_set('include_path', $locwebsvnreal.'/lib/pear'.$config->pathSeparator.ini_get('include_path'));
 @include_once 'Text/Diff.php';
 @include_once 'Text/Diff/Renderer.php';
 @include_once 'Text/Diff/Renderer/unified.php';

--- a/wsvn.php
+++ b/wsvn.php
@@ -45,8 +45,6 @@ if (!defined('WSVN_MULTIVIEWS')) {
 	define('WSVN_MULTIVIEWS', 1);
 }
 
-ini_set('include_path', $locwebsvnreal);
-
 require_once 'include/setup.php';
 require_once 'include/svnlook.php';
 


### PR DESCRIPTION
I am not 100% percent sure about the change in `wsvn.php`. It works for me because my default `include_path` is `.:/path/to/pear`. The it is right now, won't work for system-managed PEAR packages. I think it is safe to be killed while retaining all includes and requires.