### PR TITLE
Remove call not compatible with GeSHi 1.0.9.0

### DIFF
--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -754,8 +754,6 @@ class SVNRepository {
 				if ($this->geshi === null) {
 					require_once 'lib/geshi.php';
 					$this->geshi = new GeSHi();
-				} else {
-					$this->geshi->error = false;
 				}
 				$this->geshi->set_language($language);
 				if ($this->geshi->error() === false) {


### PR DESCRIPTION
Field error is private since GeSHi 1.0.9.0 and cannot be accessed from outside.