### PR TITLE
Remove PHP version checks

### DIFF
--- a/dl.php
+++ b/dl.php
@@ -31,23 +31,21 @@ require_once 'include/utils.php';
 function setDirectoryTimestamp($dir, $timestamp) {
 	global $config;
 	// Changing the timestamp of a directory in Windows is only supported in PHP 5.3.0+
-	if (!$config->serverIsWindows || version_compare(PHP_VERSION, '5.3.0alpha') !== -1) {
-		touch($dir, $timestamp);
-		if (is_dir($dir)) {
-			// Set timestamp for all contents, recursing into subdirectories
-			$handle = opendir($dir);
-			if ($handle) {
-				while (($file = readdir($handle)) !== false) {
-					if ($file == '.' || $file == '..') {
-						continue;
-					}
-					$f = $dir.DIRECTORY_SEPARATOR.$file;
-					if (is_dir($f)) {
-						setDirectoryTimestamp($f, $timestamp);
-					}
+	touch($dir, $timestamp);
+	if (is_dir($dir)) {
+		// Set timestamp for all contents, recursing into subdirectories
+		$handle = opendir($dir);
+		if ($handle) {
+			while (($file = readdir($handle)) !== false) {
+				if ($file == '.' || $file == '..') {
+					continue;
 				}
-				closedir($handle);
+				$f = $dir.DIRECTORY_SEPARATOR.$file;
+				if (is_dir($f)) {
+					setDirectoryTimestamp($f, $timestamp);
+				}
 			}
+			closedir($handle);
 		}
 	}
 }

--- a/include/diff_inc.php
+++ b/include/diff_inc.php
@@ -329,12 +329,7 @@ function inline_diff($all, $ignoreWhitespace, $highlighted, $newtname, $oldtname
 
 	// modify error reporting level to suppress deprecated/strict warning "Assigning the return value of new by reference"
 	$bckLevel = error_reporting();
-	$removeLevel = 0;
-	if (version_compare(PHP_VERSION, '5.3.0alpha') !== -1) {
-		$removeLevel = E_DEPRECATED;
-	} else if (version_compare(PHP_VERSION, '5.0.0') !== -1) {
-		$removeLevel = E_STRICT;
-	}
+	$removeLevel = E_DEPRECATED;
 	$modLevel = $bckLevel & (~$removeLevel);
 	error_reporting($modLevel);
 


### PR DESCRIPTION
You are required to use at least PHP 5.6, so not necessary for previous checks.