### PR TITLE
Bump master version to 2.4-DEV

### DIFF
--- a/include/version.php
+++ b/include/version.php
@@ -22,4 +22,4 @@
 //
 // Version information
 
-$version = '[trunk]';
+$version = '2.4-DEV';


### PR DESCRIPTION
Since Subversion is gone, [trunk] is not appropriate anymore. Moreover, if
someone works from master he/she want likely to see the version in the browser.