### PR TITLE
Add locale support for PHP and all spawned processes

### DIFF
--- a/include/configclass.php
+++ b/include/configclass.php
@@ -611,6 +611,7 @@ class WebSvnConfig {
 	var $gzip = 'gzip';
 	var $tar = 'tar';
 	var $zip = 'zip';
+	var $locale = '';
 
 	// different modes for file and folder download
 
@@ -1293,6 +1294,18 @@ class WebSvnConfig {
 
 	function getZipPath() {
 		return $this->zip;
+	}
+
+	// setLocale
+	//
+	// Set the locale for PHP and all spawned processes
+
+	function setLocale($locale) {
+		$this->locale = $locale;
+	}
+
+	function getLocale() {
+		return $this->locale;
 	}
 
 	// setDefaultFileDlMode

--- a/include/setup.php
+++ b/include/setup.php
@@ -328,7 +328,7 @@ if (file_exists('include/config.php')) {
 }
 
 // Make sure that the input locale is set up correctly
-setlocale(LC_ALL, '');
+putenv("LANG=".setlocale(LC_ALL, $config->getLocale()));
 
 // assure that a default timezone is set
 if (function_exists('date_default_timezone_get')) {


### PR DESCRIPTION
This introduces a new setLocale() method to provide a system-compatible locale.
svn(1), svnauthz(1) as well as tar/zip require a proper locale set to deal with
multibyte encodings.
putenv() should be ignored on Windows by those tools and hopefully using
wide (Unicode) versions of the Windows API.

Changed the original patch as advised by @tschoening. 