### PR TITLE
Rename wsvn.php to browse.php for better MultiViews support

### DIFF
--- a/browse.php
+++ b/browse.php
@@ -18,7 +18,7 @@
 //
 // --
 //
-// wsvn.php
+// browse.php
 //
 // Glue for MultiViews
 
@@ -28,11 +28,11 @@
 //
 // e.g. For "http://www.example.com/websvn" use '/websvn'
 //
-// Note that wsvn.php need not be in the /websvn directory (and often isn't).
+// Note that browse.php need not be in the /websvn directory (and often isn't).
 // If you want to use the root server directory, just use a blank string ('').
 $locwebsvnhttp = '/websvn';
 
-// Physical location of websvn directory. Change this if your wsvn.php is not in
+// Physical location of websvn directory. Change this if your browse.php is not in
 // the same folder as the rest of the distribution
 $locwebsvnreal = dirname(__FILE__);
 
@@ -147,7 +147,7 @@ if ($config->multiViews) {
 	include $locwebsvnreal.'/'.$file;
 
 } else {
-	$vars['error'] = 'MultiViews must be enabled in <code>include/config.php</code> in order to use <code>wsvn.php</code>. See <a href="'.$locwebsvnhttp.'/doc/install.html#multiviews">the install docs</a> for details, or use <a href="'.$locwebsvnhttp.'">this path</a> instead.';
+	$vars['error'] = 'MultiViews must be enabled in <code>include/config.php</code> in order to use <code>browse.php</code>. See <a href="'.$locwebsvnhttp.'/doc/install.html#multiviews">the install docs</a> for details, or use <a href="'.$locwebsvnhttp.'">this path</a> instead.';
 	include $locwebsvnreal.'/index.php';
 	exit;
 }

--- a/doc/install.html
+++ b/doc/install.html
@@ -129,18 +129,18 @@ $config->useEnscript();
 
 <p>You may choose to configure access to your repository via Apache's MultiView system. This will enable you to access a repository using a url such as:</p>
 
-<pre>http://example.com/wsvn/repname/path/in/repository</pre>
+<pre>http://example.com/browse/repname/path/in/repository</pre>
 
 <p>To do this you must:</p>
 
 <ul>
-	<li>Place wsvn.php where you want to. Normally you place it such that it's accessible straight after the servername, as shown above.</li>
-	<li>Configure the parent directory of wsvn.php to use MultiViews (see Apache docs)</li>
+	<li>Place browse.php where you want to. Normally you place it such that it's accessible straight after the servername, as shown above.</li>
+	<li>Configure the parent directory of browse.php to use MultiViews (see Apache docs)</li>
 	<li>Change config.php to include the line <code>$config->useMultiViews();</code></li>
-	<li>Change the path configured at the beginning of the wsvn.php script</li>
+	<li>Change the path configured at the beginning of the browse.php script</li>
 </ul>
 
-<p>Now go to <code>http://example.com/wsvn/</code> and make sure that you get the index page.</p>
+<p>Now go to <code>http://example.com/browse/</code> and make sure that you get the index page.</p>
 
 <p>The repname part of the URL is the name given to it in the config.php file.
 For this reason you may wish to avoid putting spaces in the name.</p>
@@ -164,7 +164,7 @@ For this reason you may wish to avoid putting spaces in the name.</p>
 Options MultiViews
 </pre>
 
-<p>Let's suppose that WebSVN is installed in a directory called <code>websvn</code> within the Apache document root directory. Normally, WebSVN would be accessed at <code>http://example.com/websvn/</code>. With MultiViews enabled, the base path for all WebSVN pages would be <code>http://example.com/websvn/wsvn/</code>. (If you would prefer <code>http://example.com/wsvn/</code> instead, move/copy wsvn.php from the WebSVN installation to the document root directory.) You may need to modify the <code>$locwebsvnhttp</code> variable at the beginning of wsvn.pnp to match your directory location.</p>
+<p>Let's suppose that WebSVN is installed in a directory called <code>websvn</code> within the Apache document root directory. Normally, WebSVN would be accessed at <code>http://example.com/websvn/</code>. With MultiViews enabled, the base path for all WebSVN pages would be <code>http://example.com/websvn/browse/</code>. (If you would prefer <code>http://example.com/browse/</code> instead, move/copy browse.php from the WebSVN installation to the document root directory.) You may need to modify the <code>$locwebsvnhttp</code> variable at the beginning of browse.pnp to match your directory location.</p>
 
 <p>You must also enable Multiviews in the WebSVN <code>include/config.php</code> file by adding this line:</p>
 
@@ -172,12 +172,12 @@ Options MultiViews
 $config->useMultiViews();
 </pre>
 
-<p>If all has gone well, repositories should now by accessible at <code>http://example.com/wsvn/</code>.</p>
+<p>If all has gone well, repositories should now by accessible at <code>http://example.com/browse/</code>.</p>
 
-<p>Note the index page can be accessed through <code>http://example.com/wsvn/</code>. If you want to view the index page at <code>http://example.com/</code>, you need to add another directive to the .htaccess file:</p>
+<p>Note the index page can be accessed through <code>http://example.com/browse/</code>. If you want to view the index page at <code>http://example.com/</code>, you need to add another directive to the .htaccess file:</p>
 
 <pre>
-DirectoryIndex wsvn.php
+DirectoryIndex browse.php
 </pre>
 
 <h2><a name="authentication"></a>Access rights and authentication</h2>
@@ -190,7 +190,7 @@ DirectoryIndex wsvn.php
 
 <p>Note the use of the trailing <code>/</code> in the Location directive. If you use <code>&lt;Location /websvn&gt;</code>, you won't be able to access the index.</p>
 
-<p>You should change <code>/websvn/</code> to <code>/wsvn/</code> if you're using multiviews.</p>
+<p>You should change <code>/websvn/</code> to <code>/browse/</code> if you're using multiviews.</p>
 
 <p>Also note that you should not use the <code>AuthzSVNAccessFile</code> command to define the access file.</p>
 

--- a/include/configclass.php
+++ b/include/configclass.php
@@ -1086,7 +1086,7 @@ class WebSvnConfig {
 			}
 
 			if (substr($url, -5) == 'index') {
-				$url = substr($url, 0, -5).'wsvn';
+				$url = substr($url, 0, -5).'browse';
 			}
 
 			if ($op == 'index') {

--- a/include/distconfig.php
+++ b/include/distconfig.php
@@ -209,9 +209,9 @@ $config->addTemplatePath($locwebsvnreal.'/templates/Elegant/');
 
 // Uncomment this line if you want to use MultiView to access the repository by, for example:
 //
-// http://servername/wsvn/repname/path/in/repository
+// http://servername/browse/repname/path/in/repository
 //
-// Note: The websvn directory will need to have Multiviews turned on in Apache, and you'll need to configure wsvn.php
+// Note: The websvn directory will need to have Multiviews turned on in Apache, and you'll need to configure browse.php
 
 // $config->useMultiViews();
 
@@ -221,7 +221,7 @@ $config->addTemplatePath($locwebsvnreal.'/templates/Elegant/');
 
 // Uncomment this line if you want to use your Subversion access file to control access
 // rights via WebSVN. For this to work, you'll need to set up the same Apache based authentication
-// to the WebSVN (or wsvn) directory as you have for Subversion itself. More information can be
+// to the WebSVN (or browse) directory as you have for Subversion itself. More information can be
 // found in install.txt
 
 // $config->useAccessFile('/path/to/accessfile'); // Global access file

--- a/include/setup.php
+++ b/include/setup.php
@@ -476,7 +476,7 @@ if ($peg === 0)
 $passrev = $rev;
 
 if (!$config->multiViews) {
-	// With MultiViews, wsvn creates the form once the current project is found.
+	// With MultiViews, browse creates the form once the current project is found.
 	createProjectSelectionForm();
 	createRevisionSelectionForm();
 }

--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -822,7 +822,7 @@ class SVNRepository {
 		global $config;
 
 		if ($config->useGeshi && $geshiLang = $this->highlightLanguageUsingGeshi($path)) {
-			$tempname = tempnamWithCheck($config->getTempDir(), 'wsvn');
+			$tempname = tempnamWithCheck($config->getTempDir(), 'websvn');
 			if ($tempname !== false) {
 				print toOutputEncoding($this->applyGeshi($path, $tempname, $geshiLang, $rev, $peg, true));
 				@unlink($tempname);


### PR DESCRIPTION
These days, people want beautiful to work with. Having /websvn/browse/my-repo
looks just nicer than /websvn/wsvn/my-repo.
Backwards compat can still be retained by a symlink.