### PR TITLE
Externalize user greeting in templates

### DIFF
--- a/templates/Elegant/index.tmpl
+++ b/templates/Elegant/index.tmpl
@@ -5,9 +5,7 @@
   the information passed from index.php uses drastically different organization.
   -->
   <div id="content">
-    <div class="information">
-      <span>You can customize this message in 'templates/Elegant/index.tmpl' to tell your visitors what they'll find in your repositories.</span>
-    </div>
+    [websvn-include:user_greeting.tmpl]
 [websvn-test:error]
     <div class="error"><span>[websvn:error]</span></div>
 [websvn-else]

--- a/templates/Elegant/user_greeting.tmpl
+++ b/templates/Elegant/user_greeting.tmpl
@@ -1,0 +1,3 @@
+    <div class="information">
+      <span>You can customize this message in 'templates/Elegant/index.tmpl' to tell your visitors what they'll find in your repositories.</span>
+    </div>

--- a/templates/calm/index.tmpl
+++ b/templates/calm/index.tmpl
@@ -1,12 +1,4 @@
-     <div id="info">
-     <h2>About</h2>
-     <dl>
-       <dd>You can customize this short message in the index.tmpl of this template in order to tell your visitors what they find in your repositories.</dd>
-       <dd>Visit <a href="http://www.websvn.info">www.websvn.info</a> for more information about WebSVN.</dd>
-       <dd>Learn more about Apache Subversion at <a href="http://subversion.apache.org">subversion.apache.org</a>.</dd>
-     </dl>
-     </div>
-     
+[websvn-include:user_greeting.tmpl]
 [websvn-test:error]
   <div id="error">[websvn:error]</div>
 [websvn-else]

--- a/templates/calm/user_greeting.tmpl
+++ b/templates/calm/user_greeting.tmpl
@@ -1,0 +1,8 @@
+     <div id="info">
+       <h2>About</h2>
+       <dl>
+         <dd>You can customize this short message in the index.tmpl of this template in order to tell your visitors what they find in your repositories.</dd>
+         <dd>Visit <a href="http://www.websvn.info">www.websvn.info</a> for more information about WebSVN.</dd>
+         <dd>Learn more about Apache Subversion at <a href="http://subversion.apache.org">subversion.apache.org</a>.</dd>
+       </dl>
+     </div>


### PR DESCRIPTION
Elegant and calm provide the option to display a custom user greeting, yet the
index.tmpl has to be changed which may lead to a silent overwrite during an
update. Both snippets have been factored out to user_greeting.tmpl and are
included via websvn-include directive.

This fixes #44