### PR TITLE
Use $_SERVER['CONTEXT_PREFIX'] for $locwebsvnhttp with MultiViews

### DIFF
--- a/browse.php
+++ b/browse.php
@@ -30,7 +30,7 @@
 //
 // Note that browse.php need not be in the /websvn directory (and often isn't).
 // If you want to use the root server directory, just use a blank string ('').
-$locwebsvnhttp = '/websvn';
+$locwebsvnhttp = isset($_SERVER['CONTEXT_PREFIX']) ? $_SERVER['CONTEXT_PREFIX'] : '/websvn';
 
 // Physical location of websvn directory. Change this if your browse.php is not in
 // the same folder as the rest of the distribution


### PR DESCRIPTION
When WebSVN is deployed on Apache Web Server, we required to set $locwebsvnhttp,
for now on this path is autocalculated by the server with the previous fallback.

This fixes #48