### PR TITLE
Remove PHP Warning when no extension for file

### DIFF
--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -640,7 +640,7 @@ class SVNRepository {
 		$lang = false;
 		if (array_key_exists($filename, $extEnscript)) {
 			$lang = $extEnscript[$filename];
-		} else if (array_key_exists($ext, $extEnscript)) {
+		} else if ($ext && array_key_exists($ext, $extEnscript)) {
 			$lang = $extEnscript[$ext];
 		}
 


### PR DESCRIPTION
This removes the warning message:

PHP Warning:  array_key_exists(): The first argument should be
either a string or an integer in include/svnhook.php on line 643