### PR TITLE
Fix empty lines not rendered due to non-stripped line endings in diff page

### DIFF
--- a/include/diff_inc.php
+++ b/include/diff_inc.php
@@ -101,6 +101,7 @@ function getWrappedLineFromFile($file, $is_highlighted) {
 	if (!$is_highlighted) {
 		$line = escape($line);
 	}
+	$line = rtrim($line, "\n\r");
 	if (strip_tags($line) === '') $line = '&nbsp;';
 	return wrapInCodeTagIfNecessary($line);
 }


### PR DESCRIPTION
Fix empty lines not rendered due to non-stripped line endings in diff page.

![img_diff](https://user-images.githubusercontent.com/9286319/49762982-af098f00-fccb-11e8-8649-b5d7bebb88f8.png)
