### PR TITLE
Replace header() with http_response_code()

### DIFF
--- a/blame.php
+++ b/blame.php
@@ -40,7 +40,7 @@ if ($rep) {
 		unset($vars['error']);
 		$history = $svnrep->getLog($path, '', '', false, 2, ($path == '/') ? '' : $peg);
 		if (!$history) {
-			header('HTTP/1.x 404 Not Found', true, 404);
+			http_response_code(404);
 			$vars['error'] = $lang['NOPATH'];
 		}
 	}
@@ -51,7 +51,7 @@ if ($rep) {
 	} else {
 		$history = $svnrep->getLog($path, $rev, '', false, 2, $peg);
 		if (!$history) {
-			header('HTTP/1.x 404 Not Found', true, 404);
+			http_response_code(404);
 			$vars['error'] = $lang['NOPATH'];
 		}
 	}
@@ -215,7 +215,7 @@ if ($rep) {
 	}
 
 } else {
-	header('HTTP/1.x 404 Not Found', true, 404);
+	http_response_code(404);
 }
 
 renderTemplate('blame');

--- a/comp.php
+++ b/comp.php
@@ -129,12 +129,12 @@ if ($rep) {
 
 	$history1 = $svnrep->getLog($path1, $rev1, $rev1, false, 1);
 	if (!$history1) {
-		header('HTTP/1.x 404 Not Found', true, 404);
+		http_response_code(404);
 		$vars['error'] = $lang['NOPATH'];
 	} else {
 		$history2 = $svnrep->getLog($path2, $rev2, $rev2, false, 1);
 		if (!$history2) {
-			header('HTTP/1.x 404 Not Found', true, 404);
+			http_response_code(404);
 			$vars['error'] = $lang['NOPATH'];
 		}
 	}
@@ -513,7 +513,7 @@ if ($rep) {
 	}
 
 } else {
-	header('HTTP/1.x 404 Not Found', true, 404);
+	http_response_code(404);
 }
 
 renderTemplate('compare');

--- a/diff.php
+++ b/diff.php
@@ -188,7 +188,7 @@ if ($rep) {
 	}
 
 } else {
-	header('HTTP/1.x 404 Not Found', true, 404);
+	http_response_code(404);
 }
 
 renderTemplate('diff');

--- a/dl.php
+++ b/dl.php
@@ -75,7 +75,7 @@ function removeDirectory($dir) {
 // Make sure that downloading the specified file/directory is permitted
 
 if (!$rep->isDownloadAllowed($path)) {
-	header('HTTP/1.x 403 Forbidden', true, 403);
+	http_response_code(403);
 	error_log('Unable to download resource at path: '.$path);
 	print 'Unable to download resource at path: '.xml_entities($path);
 	exit;
@@ -95,7 +95,7 @@ if ($rep) {
 	$logEntry = ($history) ? $history->entries[0] : null;
 
 	if (!$logEntry) {
-		header('HTTP/1.x 404 Not Found', true, 404);
+		http_response_code(404);
 		error_log('Unable to download resource at path: '.$path);
 		print 'Unable to download resource at path: '.xml_entities($path);
 		exit(0);
@@ -127,7 +127,7 @@ if ($rep) {
 	// Export the requested path from SVN repository to the temp directory
 	$svnExportResult = $svnrep->exportRepositoryPath($path, $tempDir.DIRECTORY_SEPARATOR.$archiveName, $rev, $peg);
 	if ($svnExportResult != 0) {
-		header('HTTP/1.x 500 Internal Server Error', true, 500);
+		http_response_code(500);
 		error_log('svn export failed for: '.$archiveName);
 		print 'svn export failed for "'.xml_entities($archiveName).'".';
 		removeDirectory($tempDir);
@@ -139,7 +139,7 @@ if ($rep) {
 	// Deciding whether the symlink is relative and legal within the
 	// repository would be nice but seems to error prone at this moment.
 	if ( is_link($tempDir.DIRECTORY_SEPARATOR.$archiveName) ) {
-		header('HTTP/1.x 500 Internal Server Error', true, 500);
+		http_response_code(500);
 		error_log('to be downloaded file is symlink, aborting: '.$archiveName);
 		print 'Download of symlinks disallowed: "'.xml_entities($archiveName).'".';
 		removeDirectory($tempDir);
@@ -208,7 +208,7 @@ if ($rep) {
 			$created = $tar->create(array($archiveName));
 			if (!$created) {
 				$retcode = 1;
-				header('HTTP/1.x 500 Internal Server Error', true, 500);
+				http_response_code(500);
 				print 'Unable to create tar archive.';
 			}
 
@@ -216,7 +216,7 @@ if ($rep) {
 			$cmd = $config->tar.' -cf '.quote($tarArchive).' '.quote($archiveName);
 			execCommand($cmd, $retcode);
 			if ($retcode != 0) {
-				header('HTTP/1.x 500 Internal Server Error', true, 500);
+				http_response_code(500);
 				error_log('Unable to call tar command: '.$cmd);
 				print 'Unable to call tar command. See webserver error log for details.';
 			}
@@ -235,7 +235,7 @@ if ($rep) {
 			$srcHandle = fopen($tarArchive, 'rb');
 			$dstHandle = gzopen($downloadArchive, 'wb');
 			if (!$srcHandle || !$dstHandle) {
-				header('HTTP/1.x 500 Internal Server Error', true, 500);
+				http_response_code(500);
 				print 'Unable to open file for gz-compression.';
 				chdir($oldcwd);
 				removeDirectory($tempDir);
@@ -252,7 +252,7 @@ if ($rep) {
 			$retcode = 0;
 			execCommand($cmd, $retcode);
 			if ($retcode != 0) {
-				header('HTTP/1.x 500 Internal Server Error', true, 500);
+				http_response_code(500);
 				error_log('Unable to call gzip command: '.$cmd);
 				print 'Unable to call gzip command. See webserver error log for details.';
 				chdir($oldcwd);
@@ -274,7 +274,7 @@ if ($rep) {
 		header('Content-Disposition: attachment; filename="'. $downloadFilename .'"');
 		readfile($downloadArchive);
 	} else {
-		header('HTTP/1.x 404 Not Found', true, 404);
+		http_response_code(404);
 		print 'Unable to open file: '.xml_entities($downloadArchive);
 	}
 
@@ -282,5 +282,5 @@ if ($rep) {
 	removeDirectory($tempDir);
 
 } else {
-	header('HTTP/1.x 404 Not Found', true, 404);
+	http_response_code(404);
 }

--- a/filedetails.php
+++ b/filedetails.php
@@ -45,7 +45,7 @@ if ($rep) {
 		unset($vars['error']);
 		$history = $svnrep->getLog($path, '', '', false, 2, ($path == '/') ? '' : $peg);
 		if (!$history) {
-			header('HTTP/1.x 404 Not Found', true, 404);
+			http_response_code(404);
 			$vars['error'] = $lang['NOPATH'];
 		}
 	}
@@ -195,12 +195,12 @@ if ($rep) {
 		$vars['error'] = $lang['NOACCESS'];
 		checkSendingAuthHeader($rep);
 	} else if (!$svnrep->isFile($path, $rev, $peg)) {
-		header('HTTP/1.x 404 Not Found', true, 404);
+		http_response_code(404);
 		$vars['error'] = $lang['NOPATH'];
 	}
 
 } else {
-	header('HTTP/1.x 404 Not Found', true, 404);
+	http_response_code(404);
 }
 
 // $listing is populated with file data when file.tmpl calls [websvn-getlisting]

--- a/include/setup.php
+++ b/include/setup.php
@@ -566,5 +566,5 @@ function checkSendingAuthHeader($rep = false) {
 		$authz =& $config->getAuthz();
 	}
 	$loggedin = $authz->hasUsername();
-	header('HTTP/1.x 403 Forbidden', true, 403);
+	http_response_code(403);
 }

--- a/include/utils.php
+++ b/include/utils.php
@@ -404,7 +404,7 @@ function tempnamWithCheck($dir, $prefix) {
 
 	if ($tmp == false) {
 		if (!headers_sent()) {
-			header('HTTP/1.x 500 Internal Server Error', true, 500);
+			http_response_code(500);
 			error_log('Unable to create a temporary file. Either make the currently used folder ("' . $dir . '") writable for WebSVN or change the folder in the configuration.');
 			print 'Unable to create a temporary file. Either make the currently used folder writable for WebSVN or change the folder in the configuration.';
 			exit(0);

--- a/listing.php
+++ b/listing.php
@@ -225,7 +225,7 @@ if ($rep) {
 		unset($vars['error']);
 		$history = $svnrep->getLog($path, '', '', false, 2, ($path == '/') ? '' : $peg);
 		if (!$history) {
-			header('HTTP/1.x 404 Not Found', true, 404);
+			http_response_code(404);
 			$vars['error'] = $lang['NOPATH'];
 		}
 	}
@@ -342,7 +342,7 @@ if ($rep) {
 	$vars['restricted'] = !$rep->hasReadAccess($path, false);
 
 } else {
-	header('HTTP/1.x 404 Not Found', true, 404);
+	http_response_code(404);
 }
 
 renderTemplate('directory');

--- a/log.php
+++ b/log.php
@@ -90,7 +90,7 @@ if ($rep) {
 		unset($vars['error']);
 		$history = $svnrep->getLog($path, '', '', false, 1, ($path == '/') ? '' : $peg);
 		if (!$history) {
-			header('HTTP/1.x 404 Not Found', true, 404);
+			http_response_code(404);
 			$vars['error'] = $lang['NOPATH'];
 		}
 	}
@@ -428,7 +428,7 @@ if ($rep) {
 	}
 
 } else {
-	header('HTTP/1.x 404 Not Found', true, 404);
+	http_response_code(404);
 }
 
 renderTemplate('log');

--- a/revision.php
+++ b/revision.php
@@ -42,7 +42,7 @@ if ($rep) {
 		unset($vars['error']);
 		$history = $svnrep->getLog($path, '', '', true, 2, ($path == '/') ? '' : $peg);
 		if (!$history) {
-			header('HTTP/1.x 404 Not Found', true, 404);
+			http_response_code(404);
 			$vars['error'] = $lang['NOPATH'];
 		}
 	}
@@ -56,7 +56,7 @@ if ($rep) {
 	$lastChangedRev = ($rev) ? $rev : $youngest;
 	$history = $svnrep->getLog($path, $lastChangedRev, 1, false, 2, $peg, true);
 	if (!$history) {
-		header('HTTP/1.x 404 Not Found', true, 404);
+		http_response_code(404);
 		$vars['error'] = $lang['NOPATH'];
 	}
 	if (empty($rev))
@@ -178,7 +178,7 @@ if ($rep) {
 	$vars['restricted'] = !$rep->hasReadAccess($path, false);
 
 } else {
-	header('HTTP/1.x 404 Not Found', true, 404);
+	http_response_code(404);
 }
 
 renderTemplate('revision');

--- a/rss.php
+++ b/rss.php
@@ -52,13 +52,13 @@ if ($path == '' || $path{0} != '/') {
 }
 
 if (!$rep) {
-	header('HTTP/1.x 404 Not Found', true, 404);
+	http_response_code(404);
 	print 'Unable to access resource at path: '.xml_entities($path);
 	exit;
 }
 // Make sure that the user has full access to the specified directory
 if (!$rep->hasReadAccess($path, false)) {
-	header('HTTP/1.x 403 Forbidden', true, 403);
+	http_response_code(403);
 	print 'Unable to access resource at path: '.xml_entities($path);
 	exit;
 }
@@ -67,7 +67,7 @@ if (!$rep->hasReadAccess($path, false)) {
 $svnrep = new SVNRepository($rep);
 $history = $svnrep->getLog($path, $rev, '', false, $max, $peg, !$quiet);
 if (!$history) {
-	header('HTTP/1.x 404 Not Found', true, 404);
+	http_response_code(404);
 	echo $lang['NOPATH'];
 	exit;
 }


### PR DESCRIPTION
Since PHP 5.4 one can use the compact form of http_response_code(int)
instead of repeating manually the status line along with the code again
by using header().