### PR TITLE
Reduced the number of hard-coded table widths within templates...

### DIFF
--- a/templates/BlueGrey/diff.tmpl
+++ b/templates/BlueGrey/diff.tmpl
@@ -53,7 +53,7 @@
       [websvn:ignorewhitespacelink]
     [websvn-endtest]
     </center>
-    <table class="diff" width="100%" cellspacing="0">
+    <table class="diff" cellspacing="0">
       <thead>
       <tr>
         <th width="50%" colspan="2"><a href="[websvn:prevrevurl]">[lang:REV] [websvn:rev2]</a></th>

--- a/templates/BlueGrey/directory.tmpl
+++ b/templates/BlueGrey/directory.tmpl
@@ -28,12 +28,12 @@
       [websvn-endtest]
     </table>
     [websvn-endtest]
-   
+
     <div id="nav">
       [websvn:revlink] &ndash;
       [websvn-test:comparelink]
       [websvn:comparelink] &ndash;
-      [websvn-endtest]    
+      [websvn-endtest]
       [websvn:loglink]
       [websvn-test:downloadurl]
       &ndash; <a href="[websvn:downloadurl]" rel="nofollow">[lang:DOWNLOAD]</a>
@@ -66,16 +66,16 @@ l-node=<img class="icon" border="0" width="24" height="22" src="[websvn:locwebsv
 e-node=<img class="icon" border="0" width="24" height="22" src="[websvn:locwebsvnhttp]/templates/BlueGrey/images/e-node.png" alt="[NODE]"/>
 [websvn-enddefineicons]
     [websvn:compare_form]
-      <table cellpadding="2" cellspacing="0" width="100%" id="listing">
+      <table cellpadding="2" cellspacing="0" id="listing">
         <thead>
         <tr>
-          <th width="100%">[lang:PATH]</th>
+          <th class="path">[lang:PATH]</th>
         [websvn-test:showlastmod]
-          <th scope="col" colspan="3">[lang:LASTMOD]</th>
+          <th class="last_mod" scope="col" colspan="3">[lang:LASTMOD]</th>
         [websvn-endtest]
-          <th nowrap="nowrap">[lang:VIEWLOG]</th>
+          <th class="view_log" nowrap="nowrap">[lang:VIEWLOG]</th>
         [websvn-test:allowdownload]
-          <th>[lang:DOWNLOAD]</th>
+          <th class="download">[lang:DOWNLOAD]</th>
         [websvn-endtest]
         [websvn-test:clientrooturl]
           <th>SVN</th>

--- a/templates/BlueGrey/header.tmpl
+++ b/templates/BlueGrey/header.tmpl
@@ -43,7 +43,7 @@
 </head>
 <body id="[websvn:template]">
   <div id="header">
-    <table width="100%" border="0">
+    <table border="0">
       <tr>
         <td width="33%">&nbsp;</td>
         <td width="33%" align="center"><a href="[websvn:indexurl]" title="[lang:PROJECTS]"><img style="border: 0; width: 272px; height: 64px;" src="[websvn:locwebsvnhttp]/templates/BlueGrey/images/websvn.png" alt="WebSVN" /></a></td>

--- a/templates/BlueGrey/log.tmpl
+++ b/templates/BlueGrey/log.tmpl
@@ -47,7 +47,7 @@
 
     [websvn-test:logsearch_resultsfound]
     [websvn:compare_form]
-      <table cellpadding="2" cellspacing="0" width="100%">
+      <table cellpadding="2" cellspacing="0">
         <thead>
         <tr>
           <th>[lang:REV]</th>
@@ -93,4 +93,4 @@
     [websvn:compare_endform]
     [websvn-endtest]
   [websvn-endtest]
-[websvn-endtest]  
+[websvn-endtest]

--- a/templates/BlueGrey/revision.tmpl
+++ b/templates/BlueGrey/revision.tmpl
@@ -36,15 +36,15 @@
     <div id="nav">
       [websvn-test:comparelink]
         [websvn:comparelink] &ndash;
-      [websvn-endtest]    
+      [websvn-endtest]
         [websvn:directorylink] &ndash;
         [websvn:loglink]
       [websvn-test:filedetaillink]
       &ndash; [websvn:filedetaillink]
-      [websvn-endtest]    
+      [websvn-endtest]
       [websvn-test:blamelink]
       &ndash; [websvn:blamelink]
-      [websvn-endtest]    
+      [websvn-endtest]
       [websvn-test:clientrooturl]
       &ndash; <a href="[websvn:clientrooturl][websvn:path]">SVN</a>
       [websvn-endtest]
@@ -55,7 +55,7 @@
   [websvn-test:warning]
     <div id="warning">[websvn:warning]</div>
   [websvn-else]
-    <table cellpadding="2" cellspacing="0" width="100%" class="outline">
+    <table cellpadding="2" cellspacing="0" class="outline">
       <thead>
       <tr>
         <th>[lang:PATH]</th>

--- a/templates/BlueGrey/styles.css
+++ b/templates/BlueGrey/styles.css
@@ -33,8 +33,9 @@ a img {
 }
 
 table {
-	border-width: 0px;
-	border-collapse: collapse;
+	border-width:		0px;
+	border-collapse:	collapse;
+	width:				100%;
 }
 
 pre {
@@ -87,6 +88,18 @@ code {
 	background-color: #809cc8;
 	padding: 1px 4px 2px 1px;
 }
+#content thead th.path {
+  text-align:	left;
+  width:		60%;
+}
+#content thead th.last_mod {
+  width: 25%;
+}
+#content thead th.view_log,
+#content thead th.download,
+#content thead th.rss {
+  width: 5%;
+}
 
 .row0, .row1 {
 	border-width: 0px;
@@ -110,7 +123,7 @@ tr.row0 th, tr.row1 th, #content td {
 	border-right: 1px solid #555;
 }
 tr.row0 th {
-	background-color: #e0e0ff	
+	background-color: #e0e0ff
 }
 tr.row1 th {
 	background-color: #d0d0ee;
@@ -197,7 +210,7 @@ div.blame-popup .date {
 }
 
 #compare #params td {
-	vertical-align: middle;	
+	vertical-align: middle;
 }
 
 #compare .comparison {

--- a/templates/calm/styles.css
+++ b/templates/calm/styles.css
@@ -432,7 +432,6 @@ tr:hover td.code {
 }
 tr td.path, tr th.path {
   text-align:left;
-  width: 100%;
 }
 tr td.path {
   padding:0;


### PR DESCRIPTION
…and fixed too wide width especially of "path"-columns. That lead to too much space between individual rows of files and directories.

![Clipboard01](https://user-images.githubusercontent.com/6223655/54881576-a6d7f880-4e51-11e9-850a-308cb1d088b7.png)
![Clipboard02](https://user-images.githubusercontent.com/6223655/54881579-a9d2e900-4e51-11e9-9743-6200de63c1e0.png)
![Clipboard03](https://user-images.githubusercontent.com/6223655/54881580-ab9cac80-4e51-11e9-84a6-f92127d9fc10.png)
![Clipboard04](https://user-images.githubusercontent.com/6223655/54881582-ae979d00-4e51-11e9-80b0-dc078c8ff1fe.png)
