### PR TITLE
Improve handling of proc_open regarding quotes and performance of cmd.exe.

### DIFF
--- a/include/authz.php
+++ b/include/authz.php
@@ -59,10 +59,17 @@ class Authorization {
 	// }}}
 
 	// Private function to simplify creation of common SVN authz command string text.
-	function svnAuthzCommandString($repos, $path, $checkSubDirs = false) {
+	function svnAuthzCommandString($repo, $path, $checkSubDirs = false) {
 		global $config;
-		return $config->getSvnAuthzCommand().' --repository '.$repos.' --path '.quote($path).
-			' '.($this->hasUsername() ? '--username '.quote($this->user).' ' : '').($checkSubDirs ? '-R ' : '').quote($this->accessfile);
+
+		$cmd			= $config->getSvnAuthzCommand();
+		$repoAndPath	= '--repository ' . quote($repo) . ' --path ' . quote($path);
+		$username		= !$this->hasUsername()	? '' : '--username ' . quote($this->user);
+		$subDirs		= !$checkSubDirs		? '' : '-R';
+		$authzFile		= quote($this->accessfile);
+		$retVal			= "${cmd} ${repoAndPath} ${username} ${subDirs} ${authzFile}";
+
+		return $retVal;
 	}
 
 	// {{{ hasReadAccess

--- a/include/command.php
+++ b/include/command.php
@@ -156,7 +156,8 @@ function runCommand($cmd, $mayReturnNothing = false, &$errorIf = 'NOT_USED') {
 
 	proc_close($resource);
 
-	if (!$error) {
+	# Some commands are expected to return no output, but warnings on STDERR.
+	if ((count($output) > 0) || $mayReturnNothing) {
 		return $output;
 	}
 

--- a/include/command.php
+++ b/include/command.php
@@ -120,6 +120,8 @@ function runCommand($cmd, $mayReturnNothing = false, &$errorIf = 'NOT_USED') {
 	$error	= '';
 	$opts	= null;
 
+	// https://github.com/websvnphp/websvn/issues/75
+	// https://github.com/websvnphp/websvn/issues/78
 	if ($config->serverIsWindows) {
 		if (!strpos($cmd, '>') && !strpos($cmd, '|')) {
 			$opts = array('bypass_shell' => true);

--- a/include/command.php
+++ b/include/command.php
@@ -119,12 +119,9 @@ function runCommand($cmd, $mayReturnNothing = false, &$errorIf = 'NOT_USED') {
 	$output	= array();
 	$error	= '';
 
-	if ($config->serverIsWindows) {
-		$cmd = '"'.$cmd.'"';
-	}
-
 	$descriptorspec	= array(0 => array('pipe', 'r'), 1 => array('pipe', 'w'), 2 => array('pipe', 'w'));
-	$resource		= proc_open($cmd, $descriptorspec, $pipes);
+	$resource		= proc_open($cmd, $descriptorspec, $pipes,
+								null, null, array('bypass_shell' => TRUE));
 
 	if (!is_resource($resource)) {
 		echo '<p>'.$lang['BADCMD'].': <code>'.stripCredentialsFromCommand($cmd).'</code></p>';

--- a/include/command.php
+++ b/include/command.php
@@ -121,7 +121,7 @@ function runCommand($cmd, $mayReturnNothing = false, &$errorIf = 'NOT_USED') {
 
 	$descriptorspec	= array(0 => array('pipe', 'r'), 1 => array('pipe', 'w'), 2 => array('pipe', 'w'));
 	$resource		= proc_open($cmd, $descriptorspec, $pipes,
-								null, null, array('bypass_shell' => TRUE));
+								null, null, array('bypass_shell' => true));
 
 	if (!is_resource($resource)) {
 		echo '<p>'.$lang['BADCMD'].': <code>'.stripCredentialsFromCommand($cmd).'</code></p>';

--- a/include/command.php
+++ b/include/command.php
@@ -118,10 +118,18 @@ function runCommand($cmd, $mayReturnNothing = false, &$errorIf = 'NOT_USED') {
 
 	$output	= array();
 	$error	= '';
+	$opts	= null;
+
+	if ($config->serverIsWindows) {
+		if (!strpos($cmd, '>') && !strpos($cmd, '|')) {
+			$opts = array('bypass_shell' => true);
+		} else {
+			$cmd = '"'.$cmd.'"';
+		}
+	}
 
 	$descriptorspec	= array(0 => array('pipe', 'r'), 1 => array('pipe', 'w'), 2 => array('pipe', 'w'));
-	$resource		= proc_open($cmd, $descriptorspec, $pipes,
-								null, null, array('bypass_shell' => true));
+	$resource		= proc_open($cmd, $descriptorspec, $pipes, null, null, $opts);
 
 	if (!is_resource($resource)) {
 		echo '<p>'.$lang['BADCMD'].': <code>'.stripCredentialsFromCommand($cmd).'</code></p>';

--- a/include/configclass.php
+++ b/include/configclass.php
@@ -618,7 +618,6 @@ class WebSvnConfig {
 
 	// Tool path locations
 
-	var $_svnCommandPrefix = '';
 	var $_svnCommandPath = '';
 	var $_svnConfigDir = '/tmp/websvn';
 	var $_svnTrustServerCert = false;
@@ -1235,18 +1234,9 @@ class WebSvnConfig {
 		$this->_updateSVNCommand();
 	}
 
-	// Define a prefix to include before every SVN command (e.g. 'arch -i386')
-	function setSvnCommandPrefix($prefix) {
-		$this->_svnCommandPrefix = $prefix;
-		$this->_updateSVNCommand();
-	}
-
 	function _updateSVNCommand() {
-		$this->_setPath($this->svn, $this->_svnCommandPath, 'svn', '--non-interactive --config-dir '.$this->_svnConfigDir.($this->_svnTrustServerCert ? ' --trust-server-cert' : ''));
-		$this->_setPath($this->svnAuthz, $this->_svnCommandPath, 'svnauthz', 'accessof');
-
-		$this->svn		= trim($this->_svnCommandPrefix.' '.$this->svn);
-		$this->svnAuthz	= trim($this->_svnCommandPrefix.' '.$this->svnAuthz);
+		$this->_setPath($this->svn,			$this->_svnCommandPath, 'svn',		'--non-interactive --config-dir '.$this->_svnConfigDir.($this->_svnTrustServerCert ? ' --trust-server-cert' : ''));
+		$this->_setPath($this->svnAuthz,	$this->_svnCommandPath, 'svnauthz',	'accessof');
 	}
 
 	function getSvnCommand() {

--- a/include/configclass.php
+++ b/include/configclass.php
@@ -1244,8 +1244,9 @@ class WebSvnConfig {
 	function _updateSVNCommand() {
 		$this->_setPath($this->svn, $this->_svnCommandPath, 'svn', '--non-interactive --config-dir '.$this->_svnConfigDir.($this->_svnTrustServerCert ? ' --trust-server-cert' : ''));
 		$this->_setPath($this->svnAuthz, $this->_svnCommandPath, 'svnauthz', 'accessof');
-		$this->svn = $this->_svnCommandPrefix.' '.$this->svn;
-		$this->svnAuthz = $this->_svnCommandPrefix.' '.$this->svnAuthz;
+
+		$this->svn		= trim($this->_svnCommandPrefix.' '.$this->svn);
+		$this->svnAuthz	= trim($this->_svnCommandPrefix.' '.$this->svnAuthz);
 	}
 
 	function getSvnCommand() {

--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -858,7 +858,7 @@ class SVNRepository {
 	function getBlameDetails($path, $filename, $rev = 0, $peg = '') {
 		$error	= '';
 		$cmd	= $this->svnCommandString('blame', $path, $rev, $peg).' > '.quote($filename);
-		$output	= runCommand($cmd, false, $error);
+		$output	= runCommand($cmd, true, $error);
 
 		if (!empty($error)) {
 			global $lang;


### PR DESCRIPTION
`proc_open` has been used multiple times in almost the same way, so In consolidated it into one place only. This should provide the chance of handling quote related problems of `cmd.exe`, which are not handled by current versions of PHP internally currently. Additionally, if not shell functionality like redirecting output into files or using pipes is needed at all, `cmd.exe` can be bypassed entirely on Windows, which should improve performance at least a bit.

This fixes #75 and #78.