### PR TITLE
PoC implementing a cache for results of checks of "svnauthz accessof".

### DIFF
--- a/include/authz.php
+++ b/include/authz.php
@@ -100,6 +100,12 @@ class Authorization {
 		$cachedExpired	= (time() - 60) > $cachedWhen;
 
 		if ($cachedExpired) {
+			// Sorting by "when" should be established somehow to only remove the oldest element
+			// instead of an arbitrary first one, which might be the newest added last time.
+			if (count($cache) >= 1000) {
+				array_shift($cache);
+			}
+
 			$result			= (runCommand($cmd))[0];
 			$cache[$cmd]	= array('when'		=> time(),
 									'result'	=> $result);

--- a/include/authz.php
+++ b/include/authz.php
@@ -60,7 +60,7 @@ class Authorization {
 	// }}}
 
 	// Private function to simplify creation of common SVN authz command string text.
-	function svnAuthzCommandString($repos, $path, $checkSubDirs = false) {
+	function svnAuthzCommandString($repo, $path, $checkSubDirs = false) {
 		global $config;
 
 		$cmd			= $config->getSvnAuthzCommand();

--- a/include/setup.php
+++ b/include/setup.php
@@ -53,7 +53,7 @@ $vars['locwebsvnhttp'] = $locwebsvnhttp;
 
 $contentType = array(
 	'.dwg'		 => 'application/acad', // AutoCAD Drawing files
-	'.arj'		 => 'application/arj', //  
+	'.arj'		 => 'application/arj', //
 	'.ccad'		=> 'application/clariscad', // ClarisCAD files
 	'.drw'		 => 'application/drafting', // MATRA Prelude drafting
 	'.dxf'		 => 'application/dxf', // DXF (AutoCAD)
@@ -68,7 +68,7 @@ $contentType = array(
 	'.wri'		 => 'application/mswrite', // Microsoft Write
 	'.bin'		 => 'application/octet-stream', // Uninterpreted binary
 	'.exe'		 => 'application/x-msdownload', // Windows EXE
-	'.oda'		 => 'application/oda', //  
+	'.oda'		 => 'application/oda', //
 	'.pdf'		 => 'application/pdf', // PDF (Adobe Acrobat)
 	'.ai'			=> 'application/postscript', // PostScript
 	'.ps'			=> 'application/postscript', // PostScript
@@ -475,8 +475,13 @@ if ($peg === 0)
 	$peg = '';
 $passrev = $rev;
 
-if (!$config->multiViews) {
-	// With MultiViews, browse creates the form once the current project is found.
+// With MultiViews, browse creates the forms once the current project is found. "index" is excluded
+// because currently no template shows a selection form on that page and generating it for no reason
+// introduces a lot of overhead in case access checks per repo need to be performed, because those
+// are actually performed twice.
+if (!$config->multiViews							&&
+	!strpos($_SERVER['SCRIPT_NAME'], 'index.php')	&&
+	!strpos($_SERVER['SCRIPT_NAME'], 'browse.php')) {
 	createProjectSelectionForm();
 	createRevisionSelectionForm();
 }

--- a/include/setup.php
+++ b/include/setup.php
@@ -53,7 +53,7 @@ $vars['locwebsvnhttp'] = $locwebsvnhttp;
 
 $contentType = array(
 	'.dwg'		 => 'application/acad', // AutoCAD Drawing files
-	'.arj'		 => 'application/arj', //
+	'.arj'		 => 'application/arj', //  
 	'.ccad'		=> 'application/clariscad', // ClarisCAD files
 	'.drw'		 => 'application/drafting', // MATRA Prelude drafting
 	'.dxf'		 => 'application/dxf', // DXF (AutoCAD)
@@ -68,7 +68,7 @@ $contentType = array(
 	'.wri'		 => 'application/mswrite', // Microsoft Write
 	'.bin'		 => 'application/octet-stream', // Uninterpreted binary
 	'.exe'		 => 'application/x-msdownload', // Windows EXE
-	'.oda'		 => 'application/oda', //
+	'.oda'		 => 'application/oda', //  
 	'.pdf'		 => 'application/pdf', // PDF (Adobe Acrobat)
 	'.ai'			=> 'application/postscript', // PostScript
 	'.ps'			=> 'application/postscript', // PostScript
@@ -475,13 +475,8 @@ if ($peg === 0)
 	$peg = '';
 $passrev = $rev;
 
-// With MultiViews, browse creates the forms once the current project is found. "index" is excluded
-// because currently no template shows a selection form on that page and generating it for no reason
-// introduces a lot of overhead in case access checks per repo need to be performed, because those
-// are actually performed twice.
-if (!$config->multiViews							&&
-	!strpos($_SERVER['SCRIPT_NAME'], 'index.php')	&&
-	!strpos($_SERVER['SCRIPT_NAME'], 'browse.php')) {
+if (!$config->multiViews) {
+	// With MultiViews, browse creates the form once the current project is found.
 	createProjectSelectionForm();
 	createRevisionSelectionForm();
 }


### PR DESCRIPTION
#78 revealed that access checks are at least performed twice for at least the index page because of creating the project selection form, so I tried to work around that by checking if the current request belongs to the index page and not create that form anymore. The problem is that WebSVN can work with MultiViews vs. not, in which case the index page is different and MultiViews could have been setup wrongly, like I did in my tests, resulting in an additional state which needs to be checked.

That doesn't make much sense in my opinion so I implemented a PoC of a cache for results of permissions checks. While such caches are somewhat unsafe, it's fully transparent to all callers, should only last about the request itself and avoids the need to deal with different entry points under different circumstances altogether.

Additionally, if e.g. a project selection form should be shown or not should be up to templates in theory and not decided based on the request to some index page. So the former approach is pretty much a workaround as well.

So let's take this PR to discuss things.

Especially because I have the feeling there are some additional bottlenecks like this one: Loading the index page took 55 s before this PR, 35 afterwards. Loading an individual repo takes ~20 s, most likely because of the project selection form checking access to all repos. But if that takes ~20 s only for one individual repo, why is it slower for the index page?

I guess it's because of things like checking all repos for `db`-files and such, but someone needs to look at this at some point.