### PR TITLE
websvn crashes if the user has access to no repositories

### DIFF
--- a/include/setup.php
+++ b/include/setup.php
@@ -565,6 +565,7 @@ function checkSendingAuthHeader($rep = false) {
 	} else {
 		$authz =& $config->getAuthz();
 	}
-	$loggedin = $authz->hasUsername();
+        // authz can be null if the user has access to no repositories
+	$loggedin = ($authz && $authz->hasUsername());
 	http_response_code(403);
 }


### PR DESCRIPTION
If a user has access to no repositories, it crashes with this error:

Fatal error: Uncaught Error: Call to a member function hasUsername() on null in /scm/share/apache2/htdocs/websvn-2.5/include/setup.php:568
Stack trace:
#0 /scm/share/apache2/htdocs/websvn-2.5/index.php(107): checkSendingAuthHeader()
#1 {main} thrown in /scm/share/apache2/htdocs/websvn-2.5/include/setup.php on line 568

This patch prevents the crash.