### PR TITLE
checkSendingAuthHeader is of no use anymore.

### DIFF
--- a/blame.php
+++ b/blame.php
@@ -211,7 +211,7 @@ if ($rep) {
 
 	if (!$rep->hasReadAccess($path, false)) {
 		$vars['error'] = $lang['NOACCESS'];
-		checkSendingAuthHeader($rep);
+		sendHeaderForbidden();
 	}
 
 } else {

--- a/comp.php
+++ b/comp.php
@@ -504,7 +504,7 @@ if ($rep) {
 				}
 				if (count($restricted) && !count($listing)) {
 					$vars['error'] = $lang['NOACCESS'];
-					checkSendingAuthHeader($rep);
+					sendHeaderForbidden();
 				}
 			}
 

--- a/diff.php
+++ b/diff.php
@@ -184,7 +184,7 @@ if ($rep) {
 
 	if (!$rep->hasReadAccess($path, false)) {
 		$vars['error'] = $lang['NOACCESS'];
-		checkSendingAuthHeader($rep);
+		sendHeaderForbidden();
 	}
 
 } else {

--- a/filedetails.php
+++ b/filedetails.php
@@ -193,7 +193,7 @@ if ($rep) {
 
 	if (!$rep->hasReadAccess($path)) {
 		$vars['error'] = $lang['NOACCESS'];
-		checkSendingAuthHeader($rep);
+		sendHeaderForbidden();
 	} else if (!$svnrep->isFile($path, $rev, $peg)) {
 		http_response_code(404);
 		$vars['error'] = $lang['NOPATH'];

--- a/include/setup.php
+++ b/include/setup.php
@@ -53,7 +53,7 @@ $vars['locwebsvnhttp'] = $locwebsvnhttp;
 
 $contentType = array(
 	'.dwg'		 => 'application/acad', // AutoCAD Drawing files
-	'.arj'		 => 'application/arj', //  
+	'.arj'		 => 'application/arj', //
 	'.ccad'		=> 'application/clariscad', // ClarisCAD files
 	'.drw'		 => 'application/drafting', // MATRA Prelude drafting
 	'.dxf'		 => 'application/dxf', // DXF (AutoCAD)
@@ -68,7 +68,7 @@ $contentType = array(
 	'.wri'		 => 'application/mswrite', // Microsoft Write
 	'.bin'		 => 'application/octet-stream', // Uninterpreted binary
 	'.exe'		 => 'application/x-msdownload', // Windows EXE
-	'.oda'		 => 'application/oda', //  
+	'.oda'		 => 'application/oda', //
 	'.pdf'		 => 'application/pdf', // PDF (Adobe Acrobat)
 	'.ai'			=> 'application/postscript', // PostScript
 	'.ps'			=> 'application/postscript', // PostScript
@@ -557,14 +557,6 @@ function createRevisionSelectionForm() {
 	$vars['revision_endform'] = '</form>';
 }
 
-function checkSendingAuthHeader($rep = false) {
-	global $config;
-	$authz = null;
-	if ($rep) {
-		$authz =& $rep->getAuthz();
-	} else {
-		$authz =& $config->getAuthz();
-	}
-	$loggedin = $authz->hasUsername();
+function sendHeaderForbidden() {
 	http_response_code(403);
 }

--- a/index.php
+++ b/index.php
@@ -76,7 +76,7 @@ foreach ($projects as $project) {
 	if ($config->showLastModInIndex()) {
 		$svnrep = new SVNRepository($project);
 		$log = $svnrep->getLog('/', '', '', true, 1);
-		
+
 		if (isset($log->entries[0])) {
 			$head = $log->entries[0];
 			$listvar['revision'] = $head->rev;
@@ -107,7 +107,7 @@ foreach ($projects as $project) {
 
 if (empty($listing) && !empty($projects)) {
 	$vars['error'] = $lang['NOACCESS'];
-	checkSendingAuthHeader();
+	sendHeaderForbidden();
 }
 
 $vars['flatview'] = $config->flatIndex;

--- a/listing.php
+++ b/listing.php
@@ -337,7 +337,7 @@ if ($rep) {
 
 	if (!$rep->hasReadAccess($path)) {
 		$vars['error'] = $lang['NOACCESS'];
-		checkSendingAuthHeader($rep);
+		sendHeaderForbidden();
 	}
 	$vars['restricted'] = !$rep->hasReadAccess($path, false);
 

--- a/log.php
+++ b/log.php
@@ -424,7 +424,7 @@ if ($rep) {
 
 	if (!$rep->hasReadAccess($path, false)) {
 		$vars['error'] = $lang['NOACCESS'];
-		checkSendingAuthHeader($rep);
+		sendHeaderForbidden();
 	}
 
 } else {

--- a/revision.php
+++ b/revision.php
@@ -167,13 +167,13 @@ if ($rep) {
 	}
 
 	if (isset($prevRev)) {
-		$vars['compareurl'] = $config->getURL($rep, '', 'comp').'compare[]='.urlencode($prevPath).'@'.$prevRev. '&amp;compare[]='.urlencode($path).'@'.$rev;	
+		$vars['compareurl'] = $config->getURL($rep, '', 'comp').'compare[]='.urlencode($prevPath).'@'.$prevRev. '&amp;compare[]='.urlencode($path).'@'.$rev;
 		$vars['comparelink'] = '<a href="'.$vars['compareurl'].'">'.$lang['DIFFPREV'].'</a>';
 	}
 
 	if (!$rep->hasReadAccess($path)) {
 		$vars['error'] = $lang['NOACCESS'];
-		checkSendingAuthHeader($rep);
+		sendHeaderForbidden();
 	}
 	$vars['restricted'] = !$rep->hasReadAccess($path, false);
 


### PR DESCRIPTION
Since handling basic auth has been removed entirely and the main logic has been commented because of problems anyway already. If it only sends a 403-header these days, all other checks are unnecessary and make unnecessary problems, so I've removed them and renamed the function.

https://github.com/websvnphp/websvn/pull/81