### PR TITLE
Try to support one WebSVN-installation hosting multiple different repos.

### DIFF
--- a/include/setup.php
+++ b/include/setup.php
@@ -345,7 +345,9 @@ if (!empty($envPathConf)) {
 	$confSuccess = 1;
 }
 if (!$confSuccess) {
-	die('No config applied, either create "include/config.php" or use environment variable "WEBSVN_PATH_CONF". The example file "include/distconfig.php" should be copied and modified as needed.');
+	die('No config applied, either create "include/config.php" or use environment variable '	.
+		'"WEBSVN_PATH_CONF". The example file "include/distconfig.php" should be copied and '	.
+		'modified as needed.');
 }
 
 // Make sure that the input locale is set up correctly

--- a/include/setup.php
+++ b/include/setup.php
@@ -317,16 +317,16 @@ $extGeshi = array(
 // Loads English localized strings by default (must go before config.php)
 require 'languages/english.php';
 
-// Support one WebSVN-installation hosting multiple different SVNParentPaths, distinguished  by their
+// Support one WebSVN installation hosting multiple different SVNParentPaths, distinguished by their
 // location. Per location, the web server needs to set some environment variable providing the path
 // to the config to either exclusively or additionally include, implementing a simple layered config
-// this way. That allows e.g. changing paths to repos per location only and share everything else.
+// this way. That allows e.g., changing paths to repos per location only and share everything else.
 //
 // The following implementation deals with multiple most likely problems in such an environment, like
-// HTTP-redirects influencing the name of the environment variable set and "preg_grep" indexing its
+// HTTP redirects influencing the name of the environment variable set and "preg_grep" indexing its
 // results depending on the input, so optionally changing between requests.
 //
-// https://stackoverflow.com/questions/3050444/when-setting-environment-variables-in-apache-rewriterule-directives-what-causes
+// https://stackoverflow.com/q/3050444/696632
 // https://bz.apache.org/bugzilla/show_bug.cgi?id=58739
 $confSuccess = 0;
 $envPathConf = preg_grep('/^(?:REDIRECT_)*WEBSVN_PATH_CONF$/', array_keys($_SERVER));

--- a/include/setup.php
+++ b/include/setup.php
@@ -317,9 +317,19 @@ $extGeshi = array(
 // Loads English localized strings by default (must go before config.php)
 require 'languages/english.php';
 
+// Try to support one WebSVN-installation hosting multiple different SVNParentPaths, distinguished
+// by their location. Per location the web server needs to set some environment variable providing
+// the path to the config to include.
+//
+// https://stackoverflow.com/questions/3050444/when-setting-environment-variables-in-apache-rewriterule-directives-what-causes
+$envConfPath = preg_grep('/^(?:REDIRECT_)*WEBSVN_PATH_CONF$/', array_keys($_SERVER));
+$envConfPath = $_SERVER[array_values($envConfPath)[0]];
+
 // Get the user's personalised config (requires the locwebsvnhttp stuff above)
 if (file_exists('include/config.php')) {
 	require_once 'include/config.php';
+} elseif (!empty($envConfPath)) {
+	require_once $envConfPath;
 } else {
 	die('File "include/config.php" does not exist, please create one. The example file "include/distconfig.php" may be copied and modified as needed.');
 }

--- a/include/setup.php
+++ b/include/setup.php
@@ -320,7 +320,7 @@ require 'languages/english.php';
 // Support one WebSVN installation hosting multiple different SVNParentPaths, distinguished by their
 // location. Per location, the web server needs to set some environment variable providing the path
 // to the config to either exclusively or additionally include, implementing a simple layered config
-// this way. That allows e.g., changing paths to repos per location only and share everything else.
+// this way. That allows, e.g., changing paths to repos per location only and share everything else.
 //
 // The following implementation deals with multiple most likely problems in such an environment, like
 // HTTP redirects influencing the name of the environment variable set and "preg_grep" indexing its

--- a/include/setup.php
+++ b/include/setup.php
@@ -317,21 +317,35 @@ $extGeshi = array(
 // Loads English localized strings by default (must go before config.php)
 require 'languages/english.php';
 
-// Try to support one WebSVN-installation hosting multiple different SVNParentPaths, distinguished
-// by their location. Per location the web server needs to set some environment variable providing
-// the path to the config to include.
+// Support one WebSVN-installation hosting multiple different SVNParentPaths, distinguished  by their
+// location. Per location, the web server needs to set some environment variable providing the path
+// to the config to either exclusively or additionally include, implementing a simple layered config
+// this way. That allows e.g. changing paths to repos per location only and share everything else.
+//
+// The following implementation deals with multiple most likely problems in such an environment, like
+// HTTP-redirects influencing the name of the environment variable set and "preg_grep" indexing its
+// results depending on the input, so optionally changing between requests.
 //
 // https://stackoverflow.com/questions/3050444/when-setting-environment-variables-in-apache-rewriterule-directives-what-causes
-$envConfPath = preg_grep('/^(?:REDIRECT_)*WEBSVN_PATH_CONF$/', array_keys($_SERVER));
-$envConfPath = $_SERVER[array_values($envConfPath)[0]];
+// https://bz.apache.org/bugzilla/show_bug.cgi?id=58739
+$confSuccess = 0;
+$envPathConf = preg_grep('/^(?:REDIRECT_)*WEBSVN_PATH_CONF$/', array_keys($_SERVER));
+$envPathConf = array_values($envPathConf);
+$envPathConf = array_key_exists(0, $envPathConf)
+				? $_SERVER[$envPathConf[0]]
+				: '';
 
-// Get the user's personalised config (requires the locwebsvnhttp stuff above)
+// Get the user's personalised config (requires the locwebsvnhttp stuff above).
 if (file_exists('include/config.php')) {
 	require_once 'include/config.php';
-} elseif (!empty($envConfPath)) {
-	require_once $envConfPath;
-} else {
-	die('File "include/config.php" does not exist, please create one. The example file "include/distconfig.php" may be copied and modified as needed.');
+	$confSuccess = 1;
+}
+if (!empty($envPathConf)) {
+	require_once $envPathConf;
+	$confSuccess = 1;
+}
+if (!$confSuccess) {
+	die('No config applied, either create "include/config.php" or use environment variable "WEBSVN_PATH_CONF". The example file "include/distconfig.php" should be copied and modified as needed.');
 }
 
 // Make sure that the input locale is set up correctly


### PR DESCRIPTION
"svnserve" is able to host SVN-repos in subdirs of a given root path, mod_dav_svn and WebSVN are not and need to get each subdir configured manually. That's especially difficult for WebSVN because it includes a config file based on a path by convention always, which is relative to the installation of WebSVN itself. So in case one wanted to use different root paths to SVN-repos, one would need multiple installations of WebSVN to provide different config files with those different SVN root paths.

This patch changes that to an approach getting the config file to use from some environment variable which can be set by the web server based on the requested location and stuff. This way one installation of WebSVN can serve different locations using different config files. The following is an example of configuring things for Apache httpd:

	<Directory "/var/www/subversion">
		AllowOverride All
		Require all granted

		RewriteEngine	On
		RewriteBase		"/"

		# Support an approach with only one WebSVN hosting multiple different configs distinguishing
		# them using environment variables based on the location. That means requested PHP-files are
		# always the same in the file system, while the location differs and needs to be forwarded
		# as-is, to e.g. let our HttpAuthnHandler find the config for an individual repo.
		RewriteRule "^websvn/.+/(.+?\.php)$"		"websvn/$1" [L]
		RewriteRule "^websvn/.+/(javascript/.+)$"	"websvn/$1" [L]
		RewriteRule "^websvn/.+/(templates/.+)$"	"websvn/$1" [L]
	</Directory>

	# While it should be able to calculate the path to the config file here using "SetEnvIf" and
	# "REQUEST_URI" with regular expressions capturing some part of the location to dynamically
	# build the path to the file, that seems pretty unsafe currently as we can't (easily?) make the
	# resulting path safe for directory traversal and stuff.
	<Directory "/var/www/subversion/websvn">
		Action application/x-httpd-php /cgi-bin/php5
	</Directory>

	<Location "/websvn/Archive/Bin/Self">
		Action		application/x-httpd-php	/cgi-bin/php5
		PerlSetVar	SVNParentPath			"/home/ams_svn_repos/Archive/Bin"
		SetEnv		WEBSVN_PATH_CONF		"/home/ams_websvn/config/Archive/Bin/Self/config.php"
	</Location>

	<LocationMatch "^/websvn/Archive/Bin/Self/(?!index|rss).+?\.php$">
		AuthName			"ams_svn_repos/Archive/Bin"
		AuthType			Basic
		PerlAuthenHandler	HttpdAuthnHandler
		Require				valid-user
	</LocationMatch>

	<Location "/websvn/Archive/Bin/Aureg">
		Action		application/x-httpd-php	/cgi-bin/php5
		PerlSetVar	SVNParentPath			"/home/ams_svn_repos/Archive/Bin/Aureg"
		SetEnv		WEBSVN_PATH_CONF		"/home/ams_websvn/config/Archive/Bin/Aureg/config.php"
	</Location>

	<LocationMatch "^/websvn/Archive/Bin/Aureg/(?!index|rss).+?\.php$">
		AuthName			"ams_svn_repos/Archive/Bin/Aureg"
		AuthType			Basic
		PerlAuthenHandler	HttpdAuthnHandler
		Require				valid-user
	</LocationMatch>

Consider this a PoC addressing #86 for now.