### PR TITLE
Show top level dirs in listing even without access to subdirs.

### DIFF
--- a/listing.php
+++ b/listing.php
@@ -107,8 +107,9 @@ function showDirFiles($svnrep, $subs, $level, $limit, $rev, $peg, $listing, $ind
 			$isDirString = ($isDir) ? 'isdir=1&amp;' : '';
 
 			// Only list files/directories that are not designated as off-limits
-			$access = ($isDir) ? $rep->hasReadAccess($path.$file, true)
-												 : $accessToThisDir;
+			$access = ($isDir)	? $rep->hasReadAccess($path.$file, false)
+								: $accessToThisDir;
+
 			if ($access) {
 				$listvar = &$listing[$index];
 				$listvar['rowparity'] = $index % 2;


### PR DESCRIPTION
#85 mentions a problem in which top level directories are not shown anymore in case of access to their subdirs is restricted for the current user. Reason is a recursive check of access to subdirs when their parent should be shown, for which nobody seems to know the reason currently. This commit reverts that behaviour.

https://github.com/websvnphp/websvn/issues/85#issuecomment-509136815
https://github.com/websvnphp/websvn/issues/85#issuecomment-509332308
