### PR TITLE
Fixed syntax error in authz.php

### DIFF
--- a/include/authz.php
+++ b/include/authz.php
@@ -106,7 +106,7 @@ class Authorization {
 				array_shift($cache);
 			}
 
-			$result			= (runCommand($cmd))[0];
+			$result			= runCommand($cmd)[0];
 			$cache[$cmd]	= array('when'		=> time(),
 									'result'	=> $result);
 		} else {


### PR DESCRIPTION
Apache currently cannot load WebSVN due to a syntax error. Apache's error log provides the following message:

`PHP Parse error:  syntax error, unexpected '[' in code.php on line 109`

Looking at the history of the file it seems to me like the brackets are misplaced, but it's possible I'm misunderstanding what it's supposed to do.

In a somewhat related question: I wanted to make use of some new features so I pulled the master branch instead of 2.5, but given it's not in a runnable state I was wondering what the general state of the master is, and if I can reliably run it? Perhaps it's better to run 2.5 patch the feature manually myself, for stability reasons.

Either way, thank you for maintaining the project.