### PR TITLE
Optional support for Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "websvnphp/websvn",
+    "description": "Online subversion repository browser",
+    "keywords": ["subversion", "svn", "websvn"],
+    "type": "project",
+    "require": {
+        "geshi/geshi": "^1.0.9",
+        "pear/archive_tar": "^1.4",
+        "pear/text_diff": "^1.2"
+    }
+}

--- a/dl.php
+++ b/dl.php
@@ -26,7 +26,9 @@ require_once 'include/setup.php';
 require_once 'include/svnlook.php';
 require_once 'include/utils.php';
 
-@include_once 'Archive/Tar.php';
+if (!defined('USE_AUTOLOADER')) {
+	@include_once 'Archive/Tar.php';
+}
 
 function setDirectoryTimestamp($dir, $timestamp) {
 	global $config;

--- a/include/diff_inc.php
+++ b/include/diff_inc.php
@@ -22,9 +22,11 @@
 //
 // Diff to files
 
-@include_once 'Text/Diff.php';
-@include_once 'Text/Diff/Renderer.php';
-@include_once 'Text/Diff/Renderer/unified.php';
+if (!defined('USE_AUTOLOADER')) {
+	@include_once 'Text/Diff.php';
+	@include_once 'Text/Diff/Renderer.php';
+	@include_once 'Text/Diff/Renderer/unified.php';
+}
 include_once 'include/diff_util.php';
 
 $arrayBased = false;

--- a/include/diff_util.php
+++ b/include/diff_util.php
@@ -24,7 +24,9 @@
 // These lines are automatically paired and also inline diff is performed to show
 // insertions/deletions on one line
 
-@include_once 'Text/Diff.php';
+if (!defined('USE_AUTOLOADER')) {
+	@include_once 'Text/Diff.php';
+}
 
 // Interface for diffing function
 class LineDiffInterface {

--- a/include/setup.php
+++ b/include/setup.php
@@ -29,6 +29,12 @@
 // Include the configuration class
 require_once 'include/configclass.php';
 
+// Register Composer autoloader if available
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+	require_once __DIR__ . '/../vendor/autoload.php';
+	define('USE_AUTOLOADER', true);
+}
+
 // Create the config
 $config = new WebSvnConfig();
 

--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -752,7 +752,9 @@ class SVNRepository {
 		foreach ($extGeshi as $language => $extensions) {
 			if (in_array($filename, $extensions) || in_array($ext, $extensions)) {
 				if ($this->geshi === null) {
-					require_once 'geshi.php';
+					if (!defined('USE_AUTOLOADER')) {
+						require_once 'geshi.php';
+					}
 					$this->geshi = new GeSHi();
 				}
 				$this->geshi->set_language($language);
@@ -788,7 +790,9 @@ class SVNRepository {
 
 		$source = file_get_contents($filename);
 		if ($this->geshi === null) {
-			require_once 'geshi.php';
+			if (!defined('USE_AUTOLOADER')) {
+				require_once 'geshi.php';
+			}
 			$this->geshi = new GeSHi();
 		}
 		$this->geshi->set_source($source);


### PR DESCRIPTION
Allow external libraries to optionally be installed through Composer rather than PEAR (issue #97).

To install the dependencies using Composer, run the command:
`composer install`