### PR TITLE
 Improve compatibility with paths and file names not encoded in UTF-8.

### DIFF
--- a/comp.php
+++ b/comp.php
@@ -378,7 +378,7 @@ if ($rep) {
 						clearVars();
 					}
 
-					$node = trim($line);
+					$node = trim(toOutputEncoding($line));
 					$node = substr($node, 7);
 					if ($node == '' || $node{0} != '/') $node = '/'.$node;
 
@@ -393,7 +393,7 @@ if ($rep) {
 					$listvar = &$listing[$index];
 					$listvar['newpath'] = escape($absnode);
 
-					$listvar['fileurl'] = $config->getURL($rep, $absnode, 'file').'rev='.$rev2;
+					$listvar['fileurl'] = $config->getURL($rep, escape($absnode), 'file').'rev='.$rev2;
 
 					if ($debug) echo 'Creating node '.$node.'<br />';
 
@@ -439,7 +439,7 @@ if ($rep) {
 
 						$node = $propnode;
 
-						$listing[$index++]['newpath'] = $node;
+						$listing[$index++]['newpath'] = escape(toOutputEncoding($node));
 						clearVars();
 					}
 

--- a/filedetails.php
+++ b/filedetails.php
@@ -111,7 +111,7 @@ if ($rep) {
 		$base = basename($path);
 		header('Content-Type: '.$mimeType);
 		//header('Content-Length: '.$size);
-		header('Content-Disposition: inline; filename='.urlencode($base));
+		header("Content-Disposition: inline; filename*=UTF-8''" . rawurlencode($base));
 		$svnrep->getFileContents($path, '', $rev, $peg);
 		exit;
 	}

--- a/include/command.php
+++ b/include/command.php
@@ -23,7 +23,7 @@
 // External command handling
 
 function detectCharacterEncoding($str) {
-	$list = array(/*'ASCII',*/ 'UTF-8', 'ISO-8859-1');
+	$list = array('windows-1252', 'ISO-8859-1', 'UTF-8');
 	if (function_exists('mb_detect_encoding')) {
 		// @see http://de3.php.net/manual/en/function.mb-detect-encoding.php#81936
 		// why appending an 'a' and specifying an encoding list is necessary

--- a/log.php
+++ b/log.php
@@ -299,6 +299,7 @@ if ($rep) {
 				$listvar['revlink'] = '<a href="'.$url.'">'.$thisrev.'</a>';
 
 				$url = $config->getURL($rep, $precisePath, ($isDir ? 'dir' : 'file')).$thisRevString;
+
 				$listvar['revpathlink'] = '<a href="'.$url.'">'.$precisePath.'</a>';
 				$listvar['revpath'] = $precisePath;
 				$listvar['revauthor'] = $revision->author;
@@ -306,8 +307,7 @@ if ($rep) {
 				$listvar['revage'] = $revision->age;
 				$listvar['revlog'] = nl2br($bugtraq->replaceIDs(create_anchors(xml_entities($revision->msg))));
 				$listvar['rowparity'] = $row;
-
-				$listvar['compareurl'] = $config->getURL($rep, '', 'comp').'compare[]='.$rpath.'@'.($thisrev - 1).'&amp;compare[]='.$rpath.'@'.$thisrev;
+				$listvar['compareurl'] = $config->getURL($rep, '', 'comp').'compare[]='.urlencode($rpath).'@'.($thisrev - 1).'&amp;compare[]='.urlencode($rpath).'@'.$thisrev;
 
 				if ($showchanges) {
 					// Aggregate added/deleted/modified paths for display in table


### PR DESCRIPTION
The download-header focuses on UTF-8 only by purpose, it's unnecessary difficult to maintain a backwards compatible file name and not necessary in current browsers anymore. https://tools.ietf.org/html/rfc6266#section-5

The second commit is to prevent the following warning:

> Notice:  iconv(): Detected an incomplete multibyte character in input string in [...]\include\command.php on line 34

![Clipboard01](https://user-images.githubusercontent.com/6223655/87519114-72f59780-c681-11ea-9a65-4567bdb886c3.png)

Tested things on Windows and that uses windows-1252 most likely. Not sure if that list-approach is good at all, because what's really needed is the default codepage of the current OS. Things look a bit difficult, though:

https://stackoverflow.com/questions/20408377/utf-8-characters-in-uploaded-file-name-are-jumbled-on-file-upload?noredirect=1&lq=1

@n0nel Please have a look an test things.

This fixes #105.