### PR TITLE
Ghi 106 too long diff path

### DIFF
--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -396,10 +396,10 @@ function logEndElement($parser, $name) {
 			$curMod = $curLog->curEntry->curMod;
 			if ($curMod->action == 'A') {
 				if ($debugxml) print 'Examining added path "'.$curMod->copyfrom.'" - Current path = "'.$curpath.'", leafname = "'.$leafname.'"'."\n";
-				if ($curLog->curEntry->curMod->path == $curLog->path) {
+				if ($curMod->path == $curLog->path) {
 					// For directories and renames
 					$curLog->path = $curMod->copyfrom;
-				} else if ($curLog->curEntry->curMod->path == $curpath || $curLog->curEntry->curMod->path == $curpath.'/') {
+				} else if ($curMod->path == $curpath || $curMod->path == $curpath.'/') {
 					// Logs of files that have moved due to branching
 					$curLog->path = $curMod->copyfrom.'/'.$leafname;
 				} else {

--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -380,6 +380,34 @@ function logEndElement($parser, $name) {
 			break;
 
 		case 'PATH':
+			// The XML returned when a file is renamed/branched in inconsistent.
+			// In the case of a branch, the path doesn't include the leafname.
+			// In the case of a rename, it does.	Ludicrous.
+
+			if (!empty($curLog->path)) {
+				$pos = strrpos($curLog->path, '/');
+				$curpath = substr($curLog->path, 0, $pos);
+				$leafname = substr($curLog->path, $pos + 1);
+			} else {
+				$curpath = '';
+				$leafname = '';
+			}
+
+			$curMod = $curLog->curEntry->curMod;
+			if ($curMod->action == 'A') {
+				if ($debugxml) print 'Examining added path "'.$curMod->copyfrom.'" - Current path = "'.$curpath.'", leafname = "'.$leafname.'"'."\n";
+				if ($curLog->curEntry->curMod->path == $curLog->path) {
+					// For directories and renames
+					$curLog->path = $curMod->copyfrom;
+				} else if ($curLog->curEntry->curMod->path == $curpath || $curLog->curEntry->curMod->path == $curpath.'/') {
+					// Logs of files that have moved due to branching
+					$curLog->path = $curMod->copyfrom.'/'.$leafname;
+				} else {
+					$curLog->path = str_replace($curMod->path, $curMod->copyfrom, $curLog->path);
+				}
+				if ($debugxml) print 'New path for comparison: "'.$curLog->path.'"'."\n";
+			}
+
 			if ($debugxml) print 'Ending path'."\n";
 			$curLog->curEntry->mods[] = $curLog->curEntry->curMod;
 			break;
@@ -433,34 +461,6 @@ function logCharacterData($parser, $data) {
 			if ($data === false || $data === '') return;
 
 			$curLog->curEntry->curMod->path .= $data;
-
-			// The XML returned when a file is renamed/branched in inconsistent.
-			// In the case of a branch, the path doesn't include the leafname.
-			// In the case of a rename, it does.	Ludicrous.
-
-			if (!empty($curLog->path)) {
-				$pos = strrpos($curLog->path, '/');
-				$curpath = substr($curLog->path, 0, $pos);
-				$leafname = substr($curLog->path, $pos + 1);
-			} else {
-				$curpath = '';
-				$leafname = '';
-			}
-
-			$curMod = $curLog->curEntry->curMod;
-			if ($curMod->action == 'A') {
-				if ($debugxml) print 'Examining added path "'.$curMod->copyfrom.'" - Current path = "'.$curpath.'", leafname = "'.$leafname.'"'."\n";
-				if ($data == $curLog->path) {
-					// For directories and renames
-					$curLog->path = $curMod->copyfrom;
-				} else if ($data == $curpath || $data == $curpath.'/') {
-					// Logs of files that have moved due to branching
-					$curLog->path = $curMod->copyfrom.'/'.$leafname;
-				} else {
-					$curLog->path = str_replace($curMod->path, $curMod->copyfrom, $curLog->path);
-				}
-				if ($debugxml) print 'New path for comparison: "'.$curLog->path.'"'."\n";
-			}
 			break;
 	}
 }


### PR DESCRIPTION
This makes the inline DIFF ni the following comment available:

https://github.com/websvnphp/websvn/issues/106#issuecomment-660745063

@n0nel Please test if this still works for your. Please provide a DIFF or even better a PR next time yourself. Copy&Paste from comments is unnecessary error prone.