### PR TITLE
Normalizing the templates for warning and changin HEAD:HEAD to HEAD:0

### DIFF
--- a/comp.php
+++ b/comp.php
@@ -127,12 +127,12 @@ if ($rep) {
 	$vars['rev1'] = $rev1;
 	$vars['rev2'] = $rev2;
 
-	$history1 = $svnrep->getLog($path1, $rev1, $rev1, false, 1);
+	$history1 = $svnrep->getLog($path1, $rev1, 0, false, 1);
 	if (!$history1) {
 		http_response_code(404);
 		$vars['error'] = $lang['NOPATH'];
 	} else {
-		$history2 = $svnrep->getLog($path2, $rev2, $rev2, false, 1);
+		$history2 = $svnrep->getLog($path2, $rev2, 0, false, 1);
 		if (!$history2) {
 			http_response_code(404);
 			$vars['error'] = $lang['NOPATH'];

--- a/templates/BlueGrey/compare.tmpl
+++ b/templates/BlueGrey/compare.tmpl
@@ -19,7 +19,7 @@
       [websvn:compare_endform]
     [websvn-test:warning]
       <div id="warning">[websvn:warning]</div>
-    [websvn-else]
+    [websvn-endtest]
     [websvn-test:success]
       <div id="nav">
         [websvn:reverselink] &#124;

--- a/templates/Elegant/compare.tmpl
+++ b/templates/Elegant/compare.tmpl
@@ -36,7 +36,6 @@
     [websvn-test:warning]
       <div id="warning">[websvn:warning]</div>
     [websvn-endtest]
-    [websvn-test:success]
     <div id="comparisons">
     [websvn-startlisting]
       [websvn-test:newpath]
@@ -66,5 +65,4 @@
     </div>
    <script type="text/javascript" src="[websvn:locwebsvnhttp]/javascript/jquery.min.1.9.1.js"></script>
    <script type="text/javascript" src="[websvn:locwebsvnhttp]/javascript/collapsible.js"></script>
-  [websvn-endtest]
 [websvn-endtest]

--- a/templates/Elegant/compare.tmpl
+++ b/templates/Elegant/compare.tmpl
@@ -35,7 +35,8 @@
     </div>
     [websvn-test:warning]
       <div id="warning">[websvn:warning]</div>
-    [websvn-else]
+    [websvn-endtest]
+    [websvn-test:success]
     <div id="comparisons">
     [websvn-startlisting]
       [websvn-test:newpath]

--- a/templates/Elegant/compare.tmpl
+++ b/templates/Elegant/compare.tmpl
@@ -33,6 +33,9 @@
     </table>
     [websvn:compare_endform]
     </div>
+    [websvn-test:warning]
+      <div id="warning">[websvn:warning]</div>
+    [websvn-else]
     <div id="comparisons">
     [websvn-startlisting]
       [websvn-test:newpath]
@@ -63,3 +66,4 @@
    <script type="text/javascript" src="[websvn:locwebsvnhttp]/javascript/jquery.min.1.9.1.js"></script>
    <script type="text/javascript" src="[websvn:locwebsvnhttp]/javascript/collapsible.js"></script>
   [websvn-endtest]
+[websvn-endtest]

--- a/templates/calm/compare.tmpl
+++ b/templates/calm/compare.tmpl
@@ -31,7 +31,6 @@
   [websvn-test:warning]
   <div id="warning">[websvn:warning]</div>
   [websvn-endtest]
-  [websvn-test:success]
   <div id="wrap">
     <h2 class="regular">
       <span class="links">
@@ -73,5 +72,4 @@
   </div>
 <script type="text/javascript" src="[websvn:locwebsvnhttp]/javascript/jquery.min.1.9.1.js"></script>
 <script type="text/javascript" src="[websvn:locwebsvnhttp]/javascript/collapsible.js"></script>
-  [websvn-endtest]
 [websvn-endtest]

--- a/templates/calm/compare.tmpl
+++ b/templates/calm/compare.tmpl
@@ -28,7 +28,9 @@
     [websvn:compare_endform]
     </li></ul>
   </div>
-  
+  [websvn-test:warning]
+  <div id="warning">[websvn:warning]</div>
+  [websvn-else]
   <div id="wrap">
     <h2 class="regular">
       <span class="links">
@@ -70,5 +72,5 @@
   </div>
 <script type="text/javascript" src="[websvn:locwebsvnhttp]/javascript/jquery.min.1.9.1.js"></script>
 <script type="text/javascript" src="[websvn:locwebsvnhttp]/javascript/collapsible.js"></script>
-
+  [websvn-endtest]
 [websvn-endtest]

--- a/templates/calm/compare.tmpl
+++ b/templates/calm/compare.tmpl
@@ -30,7 +30,8 @@
   </div>
   [websvn-test:warning]
   <div id="warning">[websvn:warning]</div>
-  [websvn-else]
+  [websvn-endtest]
+  [websvn-test:success]
   <div id="wrap">
     <h2 class="regular">
       <span class="links">


### PR DESCRIPTION
This PR is for discussion in issue #112 
The bluegrey template has a warning block in the html template whereas the other templates didnt have that.
This PR adds the warning block to templates of calm and elegant.

There has been a discussion.

> The problem is -r HEAD:HEAD and should most likely be -r HEAD:0 instead. This is related to #102.
> 
> It's not a keyword, but I think it's what you want:
> «svn log -r HEAD:0 --limit=1 -- ${TARGET}@Head»
> 

https://mail-archives.apache.org/mod_mbox/subversion-users/202005.mbox/%3C20200524220314.1a68eb8a@tarpaulin.shahaf.local2%3E

Keeping this mailing discussion in mind it was identified that 
`function getLog($path, $brev = '', $erev = 1, $quiet = false, $limit = 2, $peg = '', $verbose = false) {`

the end revision argument in the getLog function be set to zero. 