### PR TITLE
diff should return "no changes in file" between revisions for No Changes between revisions.

### DIFF
--- a/comp.php
+++ b/comp.php
@@ -474,6 +474,13 @@ if ($rep) {
 				}
 
 				$listing[$index++]['info'] = escape(toOutputEncoding($line));
+				
+				if (strlen($line) === 0) {
+					if (!$vars['warning']) {
+						$vars['warning'] = "No changes between revisions";
+					}
+				}
+				
 			}
 
 			if ($node) {


### PR DESCRIPTION
This PR is for issue #114 .

Here I have reused the warning variable to show the warning that no changes in file/path have been seen between revisions. 
This warning will be recorded only when no previous warning have been stored in the warning variable. 
The warning is triggered only when the websvn shows that diff between revision is not there. 
