### PR TITLE
Reimplementation of GHI #104 to list all dir contents.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,7 +18,7 @@ insert_final_newline		= true
 tab_width					= 4
 trim_trailing_whitespace	= true
 
-[*.{js}]
+[*.js]
 charset						= utf-8
 end_of_line					= lf
 indent_size					= 4
@@ -27,7 +27,7 @@ insert_final_newline		= true
 tab_width					= 4
 trim_trailing_whitespace	= true
 
-[*.{tmpl}]
+[*.tmpl]
 charset						= utf-8
 end_of_line					= lf
 indent_size					= 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -18,7 +18,16 @@ insert_final_newline		= true
 tab_width					= 4
 trim_trailing_whitespace	= true
 
-[*.{js,tmpl}]
+[*.{js}]
+charset						= utf-8
+end_of_line					= lf
+indent_size					= 4
+indent_style				= space
+insert_final_newline		= true
+tab_width					= 4
+trim_trailing_whitespace	= true
+
+[*.{tmpl}]
 charset						= utf-8
 end_of_line					= lf
 indent_size					= 2

--- a/include/configclass.php
+++ b/include/configclass.php
@@ -672,7 +672,7 @@ class WebSvnConfig {
 	var $authz = null;
 	var $blockRobots = false;
 
-	var $loadallrepo = false;
+	var $loadAllRepos = false;
 
 	var $templatePaths = array();
 	var $userTemplate = false;
@@ -1557,12 +1557,12 @@ class WebSvnConfig {
 		return $this->openTree;
 	}
 
-	function setLoadAllRepository($flag) {
-		$this->loadallrepo = $flag;
+	function setLoadAllRepos($flag) {
+		$this->loadAllRepos = $flag;
 	}
 
-	function showLoadAllRepository() {
-		return $this->loadallrepo;
+	function showLoadAllRepos() {
+		return $this->loadAllRepos;
 	}
 
 	function setAlphabeticOrder($flag) {

--- a/include/configclass.php
+++ b/include/configclass.php
@@ -672,6 +672,8 @@ class WebSvnConfig {
 	var $authz = null;
 	var $blockRobots = false;
 
+	var $loadallrepo = false;
+
 	var $templatePaths = array();
 	var $userTemplate = false;
 
@@ -1553,6 +1555,14 @@ class WebSvnConfig {
 
 	function getOpenTree() {
 		return $this->openTree;
+	}
+
+	function setLoadAllRepository($flag) {
+		$this->loadallrepo = $flag;
+	}
+
+	function showLoadAllRepository() {
+		return $this->loadallrepo;
 	}
 
 	function setAlphabeticOrder($flag) {

--- a/include/distconfig.php
+++ b/include/distconfig.php
@@ -171,8 +171,11 @@ $config->addTemplatePath($locwebsvnreal.'/templates/Elegant/');
 // By default all will be collapsed to root directory and can be expanded.
 // This superseeds the setAlphabeticOrder and everything will be shown in alphabetic 
 // order by default.
+// The performance will be impacted as it takes time to load up all the things in the 
+// repository. 
+// The alphabatecal order is applied to all directory and files. 
 
-// $config->setLoadAllRepository(true);
+// $config->setLoadAllRepos(true);
 
 // By default, WebSVN displays the information of the last modification
 // (revision, age and author) for each repository in an extra column.

--- a/include/distconfig.php
+++ b/include/distconfig.php
@@ -171,6 +171,8 @@ $config->addTemplatePath($locwebsvnreal.'/templates/Elegant/');
 // By default all will be collapsed to root directory and can be expanded.
 // The performance will be impacted as it takes time to load up all the things in the 
 // repository. Once loaded directory exapansion is instantaneous.
+// The alphabetical order is applied to all directory and files. 
+// This means that grouping of all dirs together and all files together is NOT supported currently!
 // The files and directories are shown as is with a mixture of files and folders. 
 
 // $config->setLoadAllRepos(true);

--- a/include/distconfig.php
+++ b/include/distconfig.php
@@ -166,6 +166,14 @@ $config->addTemplatePath($locwebsvnreal.'/templates/Elegant/');
 
 // $config->setAlphabeticOrder(true);
 
+// By default, WebSVN loads parent path directories and then on user click other,
+// This options loads the entire directory in one go and allows to browse without delay.
+// By default all will be collapsed to root directory and can be expanded.
+// This superseeds the setAlphabeticOrder and everything will be shown in alphabetic 
+// order by default.
+
+// $config->setLoadAllRepository(true);
+
 // By default, WebSVN displays the information of the last modification
 // (revision, age and author) for each repository in an extra column.
 // To disable that uncomment this line.

--- a/include/distconfig.php
+++ b/include/distconfig.php
@@ -169,11 +169,9 @@ $config->addTemplatePath($locwebsvnreal.'/templates/Elegant/');
 // By default, WebSVN loads parent path directories and then on user click other,
 // This options loads the entire directory in one go and allows to browse without delay.
 // By default all will be collapsed to root directory and can be expanded.
-// This superseeds the setAlphabeticOrder and everything will be shown in alphabetic 
-// order by default.
 // The performance will be impacted as it takes time to load up all the things in the 
-// repository. 
-// The alphabatecal order is applied to all directory and files. 
+// repository. Once loaded directory exapansion is instantaneous.
+// The files and directories are shown as is with a mixture of files and folders. 
 
 // $config->setLoadAllRepos(true);
 

--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -1042,8 +1042,6 @@ class SVNRepository {
 		$cmd = $this->svnCommandString('list -R --xml', $path, $rev, $peg);
 		$this->_xmlParseCmdOutput($cmd, 'listStartElement', 'listEndElement', 'listCharacterData');
 
-		// Sort the entries into alphabetical order
-		/*usort($curList->entries, '_listSort');*/
 		return $curList;
 	}
 

--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -488,7 +488,7 @@ function _listSort($e1, $e2) {
 	$file2 = $e2->file;
 	$isDir1 = ($file1[strlen($file1) - 1] == '/');
 	$isDir2 = ($file2[strlen($file2) - 1] == '/');
-	if (!$config->showLoadAllRepository())
+	if (!$config->showLoadAllRepos())
 	{
 		if (!$config->isAlphabeticOrder()) {
 			if ($isDir1 && !$isDir2) return -1;
@@ -1040,7 +1040,7 @@ class SVNRepository {
 			if ($headlog && isset($headlog->entries[0]))
 				$rev = $headlog->entries[0]->rev;
 		}
-		if ($config->showLoadAllRepository()) {
+		if ($config->showLoadAllRepos()) {
 			$cmd = $this->svnCommandString('list -R --xml', $path, $rev, $peg);
 		}
 		else {

--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -488,12 +488,10 @@ function _listSort($e1, $e2) {
 	$file2 = $e2->file;
 	$isDir1 = ($file1[strlen($file1) - 1] == '/');
 	$isDir2 = ($file2[strlen($file2) - 1] == '/');
-	if (!$config->showLoadAllRepos())
-	{
-		if (!$config->isAlphabeticOrder()) {
-			if ($isDir1 && !$isDir2) return -1;
-			if ($isDir2 && !$isDir1) return 1;
-		}
+
+	if (!$config->isAlphabeticOrder()) {
+		if ($isDir1 && !$isDir2) return -1;
+		if ($isDir2 && !$isDir1) return 1;
 	}
 
 	if ($isDir1) $file1 = substr($file1, 0, -1);
@@ -1040,14 +1038,17 @@ class SVNRepository {
 			if ($headlog && isset($headlog->entries[0]))
 				$rev = $headlog->entries[0]->rev;
 		}
+
 		if ($config->showLoadAllRepos()) {
 			$cmd = $this->svnCommandString('list -R --xml', $path, $rev, $peg);
+			$this->_xmlParseCmdOutput($cmd, 'listStartElement', 'listEndElement', 'listCharacterData');
 		}
 		else {
 			$cmd = $this->svnCommandString('list --xml', $path, $rev, $peg);
+			$this->_xmlParseCmdOutput($cmd, 'listStartElement', 'listEndElement', 'listCharacterData');
+			usort($curList->entries, '_listSort');
 		}
-		$this->_xmlParseCmdOutput($cmd, 'listStartElement', 'listEndElement', 'listCharacterData');
-		usort($curList->entries, '_listSort');
+
 		return $curList;
 	}
 

--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -1039,11 +1039,11 @@ class SVNRepository {
 				$rev = $headlog->entries[0]->rev;
 		}
 
-		$cmd = $this->svnCommandString('list --xml', $path, $rev, $peg);
+		$cmd = $this->svnCommandString('list -R --xml', $path, $rev, $peg);
 		$this->_xmlParseCmdOutput($cmd, 'listStartElement', 'listEndElement', 'listCharacterData');
 
 		// Sort the entries into alphabetical order
-		usort($curList->entries, '_listSort');
+		/*usort($curList->entries, '_listSort');*/
 		return $curList;
 	}
 

--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -488,10 +488,12 @@ function _listSort($e1, $e2) {
 	$file2 = $e2->file;
 	$isDir1 = ($file1[strlen($file1) - 1] == '/');
 	$isDir2 = ($file2[strlen($file2) - 1] == '/');
-
-	if (!$config->isAlphabeticOrder()) {
-		if ($isDir1 && !$isDir2) return -1;
-		if ($isDir2 && !$isDir1) return 1;
+	if (!$config->showLoadAllRepository())
+	{
+		if (!$config->isAlphabeticOrder()) {
+			if ($isDir1 && !$isDir2) return -1;
+			if ($isDir2 && !$isDir1) return 1;
+		}
 	}
 
 	if ($isDir1) $file1 = substr($file1, 0, -1);
@@ -1038,10 +1040,14 @@ class SVNRepository {
 			if ($headlog && isset($headlog->entries[0]))
 				$rev = $headlog->entries[0]->rev;
 		}
-
-		$cmd = $this->svnCommandString('list -R --xml', $path, $rev, $peg);
+		if ($config->showLoadAllRepository()) {
+			$cmd = $this->svnCommandString('list -R --xml', $path, $rev, $peg);
+		}
+		else {
+			$cmd = $this->svnCommandString('list --xml', $path, $rev, $peg);
+		}
 		$this->_xmlParseCmdOutput($cmd, 'listStartElement', 'listEndElement', 'listCharacterData');
-
+		usort($curList->entries, '_listSort');
 		return $curList;
 	}
 

--- a/javascript/collapsible.js
+++ b/javascript/collapsible.js
@@ -35,57 +35,52 @@ function collapseAllDir() {
         }
     }
 }
+
 $("table.collapsible thead").find("th").on("click", function() {
     $(this).get(0).className = ($(this).get(0).className == 'open') ? 'closed' : 'open';
     $(this).closest("table").find("tbody").toggle();
-    
 });
+
 $("tr").find("td.path").on("click",function(event) {
     event.stopPropagation();
     var $target = $(event.target);
-	console.log($target.closest("tr").attr("title"));
-	var strclass = $target.closest("tr").attr("title");
-	var res = strclass.split(" ");
-	console.log(res);
-	console.log(res[res.length - 1]);
-	// On Click Check
-	//if (!$target.closest("tr").next().attr("title")) {
-		var strclasscheck = $target.closest("tr").next().attr("title");
-		var rescheck = strclasscheck.split(" ");
-		var performaction = $target.closest("tr").attr("customaction") == 'close'? 'open' : 'close';
-		$target.closest("tr").attr("customaction",performaction);
-		while (rescheck.includes(res[res.length - 1])) {
-			if ($target.closest("tr").next().attr("customaction") != performaction) {
-				$target.closest("tr").next().attr("customaction",performaction);
-				if (performaction == 'open') {
-					$target.closest("tr").next().attr("style","visibility: visible");
-					//$target.closest("tr").next().slideDown();
-				}
-				else {
-					$target.closest("tr").next().attr("style","visibility: collapse");
-					//$target.closest("tr").next().slideUp();
-				}
-			}
-			else {
-				if (performaction == 'open') {
-					$target.closest("tr").next().attr("style","visibility: visible");
-					//$target.closest("tr").next().slideDown();
-				}
-				else {
-					$target.closest("tr").next().attr("style","visibility: collapse");
-					//$target.closest("tr").next().slideUp();
-				}
-			}
-			$target = $target.closest("tr").next();
-			// Figure out condition to stop the looping. Find the last TR element to stop the loop.
-			// Currently using the error in JS to break the loop.
-			//if (!$target.closest("tr").next().attr("title")) {
-				strclasscheck = $target.closest("tr").next().attr("title");
-				rescheck = strclasscheck.split(" ");
-			//}
-			//else {
-			//	break;
-			//}
-		}
-	//}
+    var strclass = $target.closest("tr").attr("title");
+    var res = strclass.split(" ");
+    // On Click Check
+    if ($target.closest("tr").next().attr("title") != undefined) {
+        var strclasscheck = $target.closest("tr").next().attr("title");
+        var rescheck = strclasscheck.split(" ");
+        var performaction = $target.closest("tr").attr("customaction") == 'close'? 'open' : 'close';
+        $target.closest("tr").attr("customaction",performaction);
+        while (rescheck.includes(res[res.length - 1])) {
+            if ($target.closest("tr").next().attr("customaction") != performaction) {
+                $target.closest("tr").next().attr("customaction",performaction);
+                if (performaction == 'open') {
+                    $target.closest("tr").next().attr("style","visibility: visible");
+                    $target.closest("tr").next().attr("customaction",performaction);
+                }
+                else {
+                    $target.closest("tr").next().attr("style","visibility: collapse");
+                    $target.closest("tr").next().attr("customaction",performaction);
+                }
+            }
+            else {
+                if (performaction == 'open') {
+                    $target.closest("tr").next().attr("style","visibility: visible");
+                }
+                else {
+                    $target.closest("tr").next().attr("style","visibility: collapse");
+                }
+            }
+            $target = $target.closest("tr").next();
+
+            if ($target.closest("tr").next().attr("title") == undefined) {
+                break;
+            }
+            else {
+                strclasscheck = $target.closest("tr").next().attr("title");
+                rescheck = strclasscheck.split(" ");
+            }
+        }
+    }
 });

--- a/javascript/collapsible.js
+++ b/javascript/collapsible.js
@@ -57,7 +57,7 @@ $('table#listing > tbody > tr[title*="/"]').each(function()
 {
     // "visibility: collapse" leaves some space at the bottom of the whole list, resulting in not
     // wanted scrollbars being shown by default.
-    $(this).toggle();
+    $(this).hide();
 });
 
 /**
@@ -158,7 +158,10 @@ function recursiveLoadRowParentOnHideChildren(directChildren)
 {
     $.each(directChildren, function()
     {
-        $(this).hide();
+        let self = $(this);
+
+        self.trigger('hide_children');
+        self.hide();
     });
 
     return false;

--- a/javascript/collapsible.js
+++ b/javascript/collapsible.js
@@ -18,10 +18,72 @@ function collapseAllGroups() {
       tableRows[i].style.display = 'none';
   }
 }
-
+function collapseAllDir() {
+    for (var i = 1; i < tableRows.length; i++) {
+        var strclass = tableRows[i].title;
+        var res = strclass.split(" ");
+        for (var j = i+1; j<tableRows.length; j++) {
+            var strclasscheck = tableRows[j].title;
+            var rescheck = strclasscheck.split(" ");
+            if (rescheck.includes(res[res.length - 1])) {
+                tableRows[j].style.visibility = 'collapse';
+            }
+            else {
+                i = j-1;
+                break;
+            }
+        }
+    }
+}
 $("table.collapsible thead").find("th").on("click", function() {
     $(this).get(0).className = ($(this).get(0).className == 'open') ? 'closed' : 'open';
     $(this).closest("table").find("tbody").toggle();
     
 });
-
+$("tr").find("td.path").on("click",function(event) {
+    event.stopPropagation();
+    var $target = $(event.target);
+	console.log($target.closest("tr").attr("title"));
+	var strclass = $target.closest("tr").attr("title");
+	var res = strclass.split(" ");
+	console.log(res);
+	console.log(res[res.length - 1]);
+	// On Click Check
+	if ($target.closest("tr").next() != null) {
+		var strclasscheck = $target.closest("tr").next().attr("title");
+		var rescheck = strclasscheck.split(" ");
+		var performaction = $target.closest("tr").attr("customaction") == 'close'? 'open' : 'close';
+		$target.closest("tr").attr("customaction",performaction);
+		while (rescheck.includes(res[res.length - 1])) {
+			if ($target.closest("tr").next().attr("customaction") != performaction) {
+				$target.closest("tr").next().attr("customaction",performaction);
+				if (performaction == 'open') {
+					$target.closest("tr").next().attr("style","visibility: visible");
+					//$target.closest("tr").next().slideDown();
+				}
+				else {
+					$target.closest("tr").next().attr("style","visibility: collapse");
+					//$target.closest("tr").next().slideUp();
+				}
+			}
+			else {
+				if (performaction == 'open') {
+					$target.closest("tr").next().attr("style","visibility: visible");
+					//$target.closest("tr").next().slideDown();
+				}
+				else {
+					$target.closest("tr").next().attr("style","visibility: collapse");
+					//$target.closest("tr").next().slideUp();
+				}
+			}
+			if ($target.closest("tr").next() != null) {
+				$target = $target.closest("tr").next();
+				strclasscheck = $target.closest("tr").next().attr("title");
+				rescheck = strclasscheck.split(" ");
+			}
+			else {
+				break;
+			}
+		}
+	}
+});

--- a/javascript/collapsible.js
+++ b/javascript/collapsible.js
@@ -1,90 +1,107 @@
 var tableRows = document.getElementsByTagName('tr');
 
-function toggleGroup(groupName) {
-  for (var i = 0; i < tableRows.length; i++) {
-    if (tableRows[i].title == groupName) {
-      if (tableRows[i].style.display == 'none') {
-        tableRows[i].style.display = 'table-row';
-      } else {
-        tableRows[i].style.display = 'none';
-      }
+function toggleGroup(groupName) 
+{
+
+    for (var i = 0; i < tableRows.length; i++) 
+    {
+        if (tableRows[i].title == groupName) 
+        {
+            if (tableRows[i].style.display == 'none') 
+            {
+                tableRows[i].style.display = 'table-row';
+            }
+            else 
+            {
+                tableRows[i].style.display = 'none';
+            }
+        }
     }
-  }
+
 }
 
-function collapseAllGroups() {
-  for (var i = 0; i < tableRows.length; i++) {
-    if (tableRows[i].title != '')
-      tableRows[i].style.display = 'none';
-  }
+function collapseAllGroups() 
+{
+
+    for (var i = 0; i < tableRows.length; i++) 
+    {
+        if (tableRows[i].title != '')
+            tableRows[i].style.display = 'none';
+    }
+
 }
 
-var strclass = '';
+var strClass = '';
 var res = '';
+
 $("tbody > tr").each(function() {
 
     if ($(this).attr("title") == undefined) {
         return;
     }
 
-    if (strclass == '') {
-        strclass = $(this).attr("title");
-        res = strclass.split(" ");
+    if (strClass == '') {
+        strClass = $(this).attr("title");
+        res = strClass.split(" ");
         return;
     }
 
-    let strclasscheck = $(this).attr("title");
-    let rescheck = strclasscheck.split(" ");
+    let strClassCheck = $(this).attr("title");
+    let resCheck = strClassCheck.split(" ");
 
-    if (rescheck.includes(res[res.length - 1])) {
+    if (resCheck.includes(res[res.length - 1])) {
         $(this).attr("style","visibility: collapse");
     }
     else {
-        strclass = $(this).attr("title");
-        res = strclass.split(" ");
+        strClass = $(this).attr("title");
+        res = strClass.split(" ");
     }
 
 });
 
-$("table.collapsible thead").find("th").on("click", function() {
+$("table.collapsible thead").find("th").on("click", function() 
+{
+
     $(this).get(0).className = ($(this).get(0).className == 'open') ? 'closed' : 'open';
     $(this).closest("table").find("tbody").toggle();
+
 });
 
-$("tr").find("td.path").on("click",function(event) {
+$("tr").find("td.path").on("click",function(event) 
+{
 
     event.stopPropagation();
 
     let $target = $(event.target);
-    let strclass = $target.closest("tr").attr("title");
-    let res = strclass.split(" ");
+    let strClass = $target.closest("tr").attr("title");
+    let res = strClass.split(" ");
 
     if ($target.closest("tr").next().attr("title") == undefined) {
         return;
     }
 
-    let strclasscheck = $target.closest("tr").next().attr("title");
-    let rescheck = strclasscheck.split(" ");
-    let performaction = $target.closest("tr").attr("customaction") == 'close'? 'open' : 'close';
+    let strClassCheck = $target.closest("tr").next().attr("title");
+    let resCheck = strClassCheck.split(" ");
+    let performAction = $target.closest("tr").attr("customaction") == 'close'? 'open' : 'close';
 
-    $target.closest("tr").attr("customaction",performaction);
+    $target.closest("tr").attr("customaction",performAction);
 
-    while (rescheck.includes(res[res.length - 1])) {
-        if ($target.closest("tr").next().attr("customaction") != performaction) {
-            $target.closest("tr").next().attr("customaction",performaction);
+    while (resCheck.includes(res[res.length - 1])) {
+        if ($target.closest("tr").next().attr("customaction") != performAction) {
+            $target.closest("tr").next().attr("customaction",performAction);
 
-            if (performaction == 'open') {
+            if (performAction == 'open') {
                 $target.closest("tr").next().attr("style","visibility: visible");
-                $target.closest("tr").next().attr("customaction",performaction);
+                $target.closest("tr").next().attr("customaction",performAction);
             }
             else {
                 $target.closest("tr").next().attr("style","visibility: collapse");
-                $target.closest("tr").next().attr("customaction",performaction);
+                $target.closest("tr").next().attr("customaction",performAction);
             }
         }
         else {
 
-            if (performaction == 'open') {
+            if (performAction == 'open') {
                 $target.closest("tr").next().attr("style","visibility: visible");
             }
             else {
@@ -98,8 +115,8 @@ $("tr").find("td.path").on("click",function(event) {
             break;
         }
         else {
-            strclasscheck = $target.closest("tr").next().attr("title");
-            rescheck = strclasscheck.split(" ");
+            strClassCheck = $target.closest("tr").next().attr("title");
+            resCheck = strClassCheck.split(" ");
         }
     }
 

--- a/javascript/collapsible.js
+++ b/javascript/collapsible.js
@@ -2,7 +2,6 @@ var tableRows = document.getElementsByTagName('tr');
 
 function toggleGroup(groupName) 
 {
-
     for (var i = 0; i < tableRows.length; i++) 
     {
         if (tableRows[i].title == groupName) 
@@ -17,30 +16,30 @@ function toggleGroup(groupName)
             }
         }
     }
-
 }
 
 function collapseAllGroups() 
 {
-
     for (var i = 0; i < tableRows.length; i++) 
     {
         if (tableRows[i].title != '')
+        {
             tableRows[i].style.display = 'none';
+        }
     }
-
 }
 
 var strClass = '';
 var res = '';
 
 $("tbody > tr").each(function() {
-
-    if ($(this).attr("title") == undefined) {
+    if ($(this).attr("title") == undefined) 
+    {
         return;
     }
 
-    if (strClass == '') {
+    if (strClass == '') 
+    {
         strClass = $(this).attr("title");
         res = strClass.split(" ");
         return;
@@ -49,34 +48,32 @@ $("tbody > tr").each(function() {
     let strClassCheck = $(this).attr("title");
     let resCheck = strClassCheck.split(" ");
 
-    if (resCheck.includes(res[res.length - 1])) {
+    if (resCheck.includes(res[res.length - 1])) 
+    {
         $(this).attr("style","visibility: collapse");
     }
     else {
         strClass = $(this).attr("title");
         res = strClass.split(" ");
     }
-
 });
 
 $("table.collapsible thead").find("th").on("click", function() 
 {
-
     $(this).get(0).className = ($(this).get(0).className == 'open') ? 'closed' : 'open';
     $(this).closest("table").find("tbody").toggle();
-
 });
 
 $("tr").find("td.path").on("click",function(event) 
 {
-
     event.stopPropagation();
 
     let $target = $(event.target);
     let strClass = $target.closest("tr").attr("title");
     let res = strClass.split(" ");
 
-    if ($target.closest("tr").next().attr("title") == undefined) {
+    if ($target.closest("tr").next().attr("title") == undefined) 
+    {
         return;
     }
 
@@ -86,38 +83,45 @@ $("tr").find("td.path").on("click",function(event)
 
     $target.closest("tr").attr("customaction",performAction);
 
-    while (resCheck.includes(res[res.length - 1])) {
-        if ($target.closest("tr").next().attr("customaction") != performAction) {
+    while (resCheck.includes(res[res.length - 1])) 
+    {
+        if ($target.closest("tr").next().attr("customaction") != performAction) 
+        {
             $target.closest("tr").next().attr("customaction",performAction);
 
-            if (performAction == 'open') {
+            if (performAction == 'open') 
+            {
                 $target.closest("tr").next().attr("style","visibility: visible");
                 $target.closest("tr").next().attr("customaction",performAction);
             }
-            else {
+            else 
+            {
                 $target.closest("tr").next().attr("style","visibility: collapse");
                 $target.closest("tr").next().attr("customaction",performAction);
             }
         }
-        else {
-
-            if (performAction == 'open') {
+        else 
+        {
+            if (performAction == 'open') 
+            {
                 $target.closest("tr").next().attr("style","visibility: visible");
             }
-            else {
+            else 
+            {
                 $target.closest("tr").next().attr("style","visibility: collapse");
             }
         }
 
         $target = $target.closest("tr").next();
 
-        if ($target.closest("tr").next().attr("title") == undefined) {
+        if ($target.closest("tr").next().attr("title") == undefined) 
+        {
             break;
         }
-        else {
+        else 
+        {
             strClassCheck = $target.closest("tr").next().attr("title");
             resCheck = strClassCheck.split(" ");
         }
     }
-
 });

--- a/javascript/collapsible.js
+++ b/javascript/collapsible.js
@@ -49,7 +49,7 @@ $("tr").find("td.path").on("click",function(event) {
 	console.log(res);
 	console.log(res[res.length - 1]);
 	// On Click Check
-	if ($target.closest("tr").next() != null) {
+	//if (!$target.closest("tr").next().attr("title")) {
 		var strclasscheck = $target.closest("tr").next().attr("title");
 		var rescheck = strclasscheck.split(" ");
 		var performaction = $target.closest("tr").attr("customaction") == 'close'? 'open' : 'close';
@@ -76,14 +76,16 @@ $("tr").find("td.path").on("click",function(event) {
 					//$target.closest("tr").next().slideUp();
 				}
 			}
-			if ($target.closest("tr").next() != null) {
-				$target = $target.closest("tr").next();
+			$target = $target.closest("tr").next();
+			// Figure out condition to stop the looping. Find the last TR element to stop the loop.
+			// Currently using the error in JS to break the loop.
+			//if (!$target.closest("tr").next().attr("title")) {
 				strclasscheck = $target.closest("tr").next().attr("title");
 				rescheck = strclasscheck.split(" ");
-			}
-			else {
-				break;
-			}
+			//}
+			//else {
+			//	break;
+			//}
 		}
-	}
+	//}
 });

--- a/javascript/collapsible.js
+++ b/javascript/collapsible.js
@@ -29,34 +29,23 @@ function collapseAllGroups()
     }
 }
 
-var strClass = '';
-var res = '';
-
-$("tbody > tr").each(function() {
+$("table#listing > tbody > tr").each(function() {
     if ($(this).attr("title") == undefined) 
     {
         return;
     }
 
-    if (strClass == '') 
+    let strClass = '';
+    let res = '';
+    strClass = $(this).attr("title");
+    res = strClass.split(" ");
+
+    if (res.length <= 1)
     {
-        strClass = $(this).attr("title");
-        res = strClass.split(" ");
         return;
     }
 
-    let strClassCheck = $(this).attr("title");
-    let resCheck = strClassCheck.split(" ");
-
-    if (resCheck.includes(res[res.length - 1])) 
-    {
-        $(this).attr("style","visibility: collapse");
-    }
-    else 
-    {
-        strClass = $(this).attr("title");
-        res = strClass.split(" ");
-    }
+    $(this).attr("style","visibility: collapse");
 });
 
 $("table.collapsible thead").find("th").on("click", function() 
@@ -78,7 +67,7 @@ $("tr").find("td.path").on("click",function(event)
         return;
     }
 
-    if ($target.children('a').children('img').attr('alt') == '[FILE]')
+    if ($target.children('a').children('img').attr('alt') != '[DIRECTORY]')
     {
         return;
     }

--- a/javascript/collapsible.js
+++ b/javascript/collapsible.js
@@ -89,7 +89,27 @@ $('table#listing > tbody').each(function()
         {
             $.each(directChildren, function()
             {
-                $(this).toggle();
+                let self        = $(this);
+                let isVisible   = self.is(':visible');
+
+                if (!isVisible)
+                {
+                    self.show();
+                    return true;
+                }
+
+                self.trigger('hide_children');
+                self.hide();
+            });
+
+            return false;
+        });
+
+        rowParent.on('hide_children', function()
+        {
+            $.each(directChildren, function()
+            {
+                $(this).hide();
             });
 
             return false;

--- a/javascript/collapsible.js
+++ b/javascript/collapsible.js
@@ -19,26 +19,32 @@ function collapseAllGroups() {
   }
 }
 
-function collapseAllDir() {
+var strclass = '';
+var res = '';
+$("tbody > tr").each(function() {
 
-    for (let i = 1; i < tableRows.length; i++) {
-        let strclass = tableRows[i].title;
-        let res = strclass.split(" ");
-
-        for (let j = i+1; j<tableRows.length; j++) {
-            let strclasscheck = tableRows[j].title;
-            let rescheck = strclasscheck.split(" ");
-
-            if (rescheck.includes(res[res.length - 1])) {
-                tableRows[j].style.visibility = 'collapse';
-            }
-            else {
-                i = j-1;
-                break;
-            }
-        }
+    if ($(this).attr("title") == undefined) {
+        return;
     }
-}
+
+    if (strclass == '') {
+        strclass = $(this).attr("title");
+        res = strclass.split(" ");
+        return;
+    }
+
+    let strclasscheck = $(this).attr("title");
+    let rescheck = strclasscheck.split(" ");
+
+    if (rescheck.includes(res[res.length - 1])) {
+        $(this).attr("style","visibility: collapse");
+    }
+    else {
+        strclass = $(this).attr("title");
+        res = strclass.split(" ");
+    }
+
+});
 
 $("table.collapsible thead").find("th").on("click", function() {
     $(this).get(0).className = ($(this).get(0).className == 'open') ? 'closed' : 'open';

--- a/javascript/collapsible.js
+++ b/javascript/collapsible.js
@@ -29,6 +29,15 @@ function collapseAllGroups()
     }
 }
 
+$("table.collapsible thead").find("th").on("click", function()
+{
+    let oldClass = $(this).get(0).className;
+    let newClass = (oldClass == 'open') ? 'closed' : 'open';
+
+    $(this).get(0).className = newClass;
+    $(this).closest("table").find("tbody").toggle();
+});
+
 $("table#listing > tbody > tr").each(function()
 {
     if ($(this).attr("title") == undefined)
@@ -45,15 +54,6 @@ $("table#listing > tbody > tr").each(function()
     }
 
     $(this).attr("style", "visibility: collapse");
-});
-
-$("table.collapsible thead").find("th").on("click", function()
-{
-    let oldClass = $(this).get(0).className;
-    let newClass = (oldClass == 'open') ? 'closed' : 'open';
-
-    $(this).get(0).className = newClass;
-    $(this).closest("table").find("tbody").toggle();
 });
 
 $("tr").find("td.path").on("click", function(event)

--- a/javascript/collapsible.js
+++ b/javascript/collapsible.js
@@ -77,7 +77,11 @@ $('table#listing > tbody > tr[title*="/"]').each(function()
  */
 function recursiveLoadDirectChildrenSelect(body, rowParent)
 {
+    // The parent title is used in some reg exp, so properly escape/quote it. Sadly "\Q...\E" does
+    // not work and JS doesn't seem to provide anythign else on its own as well.
+    // https://stackoverflow.com/a/3561711/2055163
     let titleParent     = rowParent.attr('title') || '';
+        titleParent     = titleParent.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
     let selector        = 'tr[title^="' + titleParent + '/"]';
     let directChildren  = [];
 
@@ -89,8 +93,6 @@ function recursiveLoadDirectChildrenSelect(body, rowParent)
         let rowChild    = $(this);
         let titleChild  = rowChild.attr('title') || '';
 
-        // TODO \Q...\E doesn't work, pattern needs to be escaped properly somehow
-        // https://makandracards.com/makandra/15879-javascript-how-to-generate-a-regular-expression-from-a-string
         let ptChildDirs     = titleParent + '/$';
         let ptChildFiles    = titleParent + '/[^/]+$';
         let pattern         = ptChildDirs + '|' + ptChildFiles;

--- a/javascript/collapsible.js
+++ b/javascript/collapsible.js
@@ -177,8 +177,15 @@ function recursiveLoadRowProc(body, rowParent)
 {
     let directChildren = recursiveLoadDirectChildrenSelect(body, rowParent);
 
-    rowParent.on('click',           function() { return recursiveLoadRowParentOnClick(directChildren); });
-    rowParent.on('hide_children',   function() { return recursiveLoadRowParentOnHideChildren(directChildren);});
+    rowParent.find('td.path a[href^="listing.php?"]').on('click', function()
+    {
+        return recursiveLoadRowParentOnClick(directChildren);
+    });
+
+    rowParent.on('hide_children', function()
+    {
+        return recursiveLoadRowParentOnHideChildren(directChildren);
+    });
 }
 
 /**

--- a/javascript/collapsible.js
+++ b/javascript/collapsible.js
@@ -18,13 +18,17 @@ function collapseAllGroups() {
       tableRows[i].style.display = 'none';
   }
 }
+
 function collapseAllDir() {
-    for (var i = 1; i < tableRows.length; i++) {
-        var strclass = tableRows[i].title;
-        var res = strclass.split(" ");
-        for (var j = i+1; j<tableRows.length; j++) {
-            var strclasscheck = tableRows[j].title;
-            var rescheck = strclasscheck.split(" ");
+
+    for (let i = 1; i < tableRows.length; i++) {
+        let strclass = tableRows[i].title;
+        let res = strclass.split(" ");
+
+        for (let j = i+1; j<tableRows.length; j++) {
+            let strclasscheck = tableRows[j].title;
+            let rescheck = strclasscheck.split(" ");
+
             if (rescheck.includes(res[res.length - 1])) {
                 tableRows[j].style.visibility = 'collapse';
             }
@@ -42,45 +46,55 @@ $("table.collapsible thead").find("th").on("click", function() {
 });
 
 $("tr").find("td.path").on("click",function(event) {
-    event.stopPropagation();
-    var $target = $(event.target);
-    var strclass = $target.closest("tr").attr("title");
-    var res = strclass.split(" ");
-    // On Click Check
-    if ($target.closest("tr").next().attr("title") != undefined) {
-        var strclasscheck = $target.closest("tr").next().attr("title");
-        var rescheck = strclasscheck.split(" ");
-        var performaction = $target.closest("tr").attr("customaction") == 'close'? 'open' : 'close';
-        $target.closest("tr").attr("customaction",performaction);
-        while (rescheck.includes(res[res.length - 1])) {
-            if ($target.closest("tr").next().attr("customaction") != performaction) {
-                $target.closest("tr").next().attr("customaction",performaction);
-                if (performaction == 'open') {
-                    $target.closest("tr").next().attr("style","visibility: visible");
-                    $target.closest("tr").next().attr("customaction",performaction);
-                }
-                else {
-                    $target.closest("tr").next().attr("style","visibility: collapse");
-                    $target.closest("tr").next().attr("customaction",performaction);
-                }
-            }
-            else {
-                if (performaction == 'open') {
-                    $target.closest("tr").next().attr("style","visibility: visible");
-                }
-                else {
-                    $target.closest("tr").next().attr("style","visibility: collapse");
-                }
-            }
-            $target = $target.closest("tr").next();
 
-            if ($target.closest("tr").next().attr("title") == undefined) {
-                break;
+    event.stopPropagation();
+
+    let $target = $(event.target);
+    let strclass = $target.closest("tr").attr("title");
+    let res = strclass.split(" ");
+
+    if ($target.closest("tr").next().attr("title") == undefined) {
+        return;
+    }
+
+    let strclasscheck = $target.closest("tr").next().attr("title");
+    let rescheck = strclasscheck.split(" ");
+    let performaction = $target.closest("tr").attr("customaction") == 'close'? 'open' : 'close';
+
+    $target.closest("tr").attr("customaction",performaction);
+
+    while (rescheck.includes(res[res.length - 1])) {
+        if ($target.closest("tr").next().attr("customaction") != performaction) {
+            $target.closest("tr").next().attr("customaction",performaction);
+
+            if (performaction == 'open') {
+                $target.closest("tr").next().attr("style","visibility: visible");
+                $target.closest("tr").next().attr("customaction",performaction);
             }
             else {
-                strclasscheck = $target.closest("tr").next().attr("title");
-                rescheck = strclasscheck.split(" ");
+                $target.closest("tr").next().attr("style","visibility: collapse");
+                $target.closest("tr").next().attr("customaction",performaction);
             }
         }
+        else {
+
+            if (performaction == 'open') {
+                $target.closest("tr").next().attr("style","visibility: visible");
+            }
+            else {
+                $target.closest("tr").next().attr("style","visibility: collapse");
+            }
+        }
+
+        $target = $target.closest("tr").next();
+
+        if ($target.closest("tr").next().attr("title") == undefined) {
+            break;
+        }
+        else {
+            strclasscheck = $target.closest("tr").next().attr("title");
+            rescheck = strclasscheck.split(" ");
+        }
     }
+
 });

--- a/javascript/collapsible.js
+++ b/javascript/collapsible.js
@@ -72,9 +72,12 @@ $('table#listing > tbody').each(function()
         {
             let rowChild    = $(this);
             let titleChild  = rowChild.attr('title') || '';
+
             // TODO \Q...\E doesn't work, pattern needs to be escaped properly somehow
             // https://makandracards.com/makandra/15879-javascript-how-to-generate-a-regular-expression-from-a-string
-            let pattern = titleParent + '/[^/]+$';
+            let ptChildDirs     = titleParent + '/$';
+            let ptChildFiles    = titleParent + '/[^/]+$';
+            let pattern         = ptChildDirs + '|' + ptChildFiles;
 
             if (titleChild.match(pattern))
             {

--- a/javascript/collapsible.js
+++ b/javascript/collapsible.js
@@ -1,16 +1,16 @@
 var tableRows = document.getElementsByTagName('tr');
 
-function toggleGroup(groupName) 
+function toggleGroup(groupName)
 {
-    for (var i = 0; i < tableRows.length; i++) 
+    for (var i = 0; i < tableRows.length; i++)
     {
-        if (tableRows[i].title == groupName) 
+        if (tableRows[i].title == groupName)
         {
-            if (tableRows[i].style.display == 'none') 
+            if (tableRows[i].style.display == 'none')
             {
                 tableRows[i].style.display = 'table-row';
             }
-            else 
+            else
             {
                 tableRows[i].style.display = 'none';
             }
@@ -18,9 +18,9 @@ function toggleGroup(groupName)
     }
 }
 
-function collapseAllGroups() 
+function collapseAllGroups()
 {
-    for (var i = 0; i < tableRows.length; i++) 
+    for (var i = 0; i < tableRows.length; i++)
     {
         if (tableRows[i].title != '')
         {
@@ -29,40 +29,44 @@ function collapseAllGroups()
     }
 }
 
-$("table#listing > tbody > tr").each(function() {
-    if ($(this).attr("title") == undefined) 
+$("table#listing > tbody > tr").each(function()
+{
+    if ($(this).attr("title") == undefined)
     {
         return;
     }
 
-    let strClass = '';
-    let res = '';
-    strClass = $(this).attr("title");
-    res = strClass.split(" ");
+    let strClass  = $(this).attr("title");
+    let res       = strClass.split(" ");
 
     if (res.length <= 1)
     {
         return;
     }
 
-    $(this).attr("style","visibility: collapse");
+    $(this).attr("style", "visibility: collapse");
 });
 
-$("table.collapsible thead").find("th").on("click", function() 
+$("table.collapsible thead").find("th").on("click", function()
 {
-    $(this).get(0).className = ($(this).get(0).className == 'open') ? 'closed' : 'open';
+    let oldClass = $(this).get(0).className;
+    let newClass = (oldClass == 'open') ? 'closed' : 'open';
+
+    $(this).get(0).className = newClass;
     $(this).closest("table").find("tbody").toggle();
 });
 
-$("tr").find("td.path").on("click",function(event) 
+$("tr").find("td.path").on("click", function(event)
 {
     event.stopPropagation();
 
-    let $target = $(event.target);
-    let strClass = $target.closest("tr").attr("title");
-    let res = strClass.split(" ");
+    let $target   = $(event.target);
+    let trItself  = $target.closest("tr");
+    let trNext    = trItself.next();
+    let strClass  = trItself.attr("title");
+    let res       = strClass.split(" ");
 
-    if ($target.closest("tr").next().attr("title") == undefined) 
+    if (trNext.attr("title") == undefined)
     {
         return;
     }
@@ -72,51 +76,48 @@ $("tr").find("td.path").on("click",function(event)
         return;
     }
 
-    let strClassCheck = $target.closest("tr").next().attr("title");
-    let resCheck = strClassCheck.split(" ");
-    let performAction = $target.closest("tr").attr("customaction") == 'close'? 'open' : 'close';
+    let strClassCheck = trNext.attr("title");
+    let resCheck      = strClassCheck.split(" ");
+    let oldAction     = trItself.attr("customaction");
+    let newAction     = oldAction == 'close'? 'open' : 'close';
 
-    $target.closest("tr").attr("customaction",performAction);
+    trItself.attr("customaction", newAction);
 
-    while (resCheck.includes(res[res.length - 1])) 
+    while (resCheck.includes(res[res.length - 1]))
     {
-        if ($target.closest("tr").next().attr("customaction") != performAction) 
+        if (trNext.attr("customaction") != newAction)
         {
-            $target.closest("tr").next().attr("customaction",performAction);
+            trNext.attr("customaction", newAction);
 
-            if (performAction == 'open') 
+            if (newAction == 'open')
             {
-                $target.closest("tr").next().attr("style","visibility: visible");
-                $target.closest("tr").next().attr("customaction",performAction);
+                trNext.attr("style",        "visibility: visible");
+                trNext.attr("customaction", newAction);
             }
-            else 
+            else
             {
-                $target.closest("tr").next().attr("style","visibility: collapse");
-                $target.closest("tr").next().attr("customaction",performAction);
+                trNext.attr("style",        "visibility: collapse");
+                trNext.attr("customaction", newAction);
             }
         }
-        else 
+        else
         {
-            if (performAction == 'open') 
+            if (newAction == 'open')
             {
-                $target.closest("tr").next().attr("style","visibility: visible");
+                trNext.attr("style", "visibility: visible");
             }
-            else 
+            else
             {
-                $target.closest("tr").next().attr("style","visibility: collapse");
+                trNext.attr("style", "visibility: collapse");
             }
         }
 
-        $target = $target.closest("tr").next();
-
-        if ($target.closest("tr").next().attr("title") == undefined) 
+        if (trNext.attr("title") == undefined)
         {
             break;
         }
-        else 
-        {
-            strClassCheck = $target.closest("tr").next().attr("title");
-            resCheck = strClassCheck.split(" ");
-        }
+
+        strClassCheck = trNext.attr("title");
+        resCheck      = strClassCheck.split(" ");
     }
 });

--- a/javascript/collapsible.js
+++ b/javascript/collapsible.js
@@ -38,9 +38,21 @@ $("table.collapsible thead").find("th").on("click", function()
     $(this).closest("table").find("tbody").toggle();
 });
 
-// TODO docs,
-// initially hide all non-root entries, especially in case of "setLoadAllRepos"
-// only roots DON'T contain any delimiter for directories and files currently
+/**
+ * Hide all non-root entries currently visible.
+ * <p>
+ * Depending on the config, the site is able to load ALL files and directories of the current repo
+ * recursively to prevent additional requests. The use case is to hide all of the root-dirs and let
+ * users simply toggle the next level of interest without additional waiting. This is implemented by
+ * using the {@code title}-attribute and the {@code /}-character to represent some path and ONLY the
+ * root-dirs themself to show DON'T contain such. All other entries have some, either because they
+ * belong to a subdir or file within some parent dir.
+ * </p>
+ * <p>
+ * There's currently no additional config necessary to apply this JS or not, because the rows worked
+ * on are only generated in case recursive loading is enabled already!
+ * </p>
+ */
 $('table#listing > tbody > tr[title*="/"]').each(function()
 {
     // "visibility: collapse" leaves some space at the bottom of the whole list, resulting in not
@@ -48,7 +60,130 @@ $('table#listing > tbody > tr[title*="/"]').each(function()
     $(this).toggle();
 });
 
-// TODO docs, make parents toggle their DIRECT children only
+/**
+ * Select all direct children for the given parent.
+ * <p>
+ * The markup doesn't model parent-child relationships currently, but instead all directories,
+ * files etc. are maintained as individual rows one after each other. In theory not even the order
+ * of those rows needs to be alphabetically or fit the parent-child-order in the repo or else, all
+ * can be mixed-up. So this function searches all rows of the given {@code body} for DIRECT children
+ * of the given parent row, which can be identified by their paths maintained in the {@code title}-
+ * attribute. Such filtering is non-trivial and one can't use CSS-selectors only, because those
+ * paths need to fulfill certain conditions.
+ * </p>
+ * @param[in] body
+ * @param[in] rowParent
+ * @return Array with direct children of the given parent.
+ */
+function recursiveLoadDirectChildrenSelect(body, rowParent)
+{
+    let titleParent     = rowParent.attr('title') || '';
+    let selector        = 'tr[title^="' + titleParent + '/"]';
+    let directChildren  = [];
+
+    // Selectors don't support regular expressions, but direct children not only start with the
+    // parent, but don't contain additional children in their title as well. One can't select
+    // that condition easily, so find ALL children and filter later to direct ones only.
+    body.children(selector).each(function()
+    {
+        let rowChild    = $(this);
+        let titleChild  = rowChild.attr('title') || '';
+
+        // TODO \Q...\E doesn't work, pattern needs to be escaped properly somehow
+        // https://makandracards.com/makandra/15879-javascript-how-to-generate-a-regular-expression-from-a-string
+        let ptChildDirs     = titleParent + '/$';
+        let ptChildFiles    = titleParent + '/[^/]+$';
+        let pattern         = ptChildDirs + '|' + ptChildFiles;
+
+        if (titleChild.match(pattern))
+        {
+            directChildren.push(rowChild);
+        }
+    });
+
+    return directChildren;
+}
+
+/**
+ * Click-handler for some parent directory.
+ * <p>
+ * What needs to happen depends on the visibility of the direct children associated with some parent
+ * and therefore given: If children are NOT visible, simply show them and ONLY those, as showing
+ * should not be recursive currently. If children are visible OTOH, ALL of those need to be hidden
+ * or otherwise some lower level children would still be shown. This is because of the currently
+ * used markup, which doesn't model parent-child-relationships properly, but places everything at
+ * one level. Someone needs to take care of hiding children of children of children, when hiding
+ * associated markup itself only hides some of those. To hide recursively, a custom event named
+ * {@code hide_children} seems the easiest approach currently, which is then simply handled by the
+ * parent directory again.
+ * </p>
+ * @param[in] directChildren
+ * @return {@code false} to stop propagation of the current event.
+ */
+function recursiveLoadRowParentOnClick(directChildren)
+{
+    $.each(directChildren, function()
+    {
+        let self        = $(this);
+        let isVisible   = self.is(':visible');
+
+        if (!isVisible)
+        {
+            self.show();
+            return true;
+        }
+
+        self.trigger('hide_children');
+        self.hide();
+    });
+
+    return false;
+}
+
+/**
+ * Handler to hide direct children.
+ * <p>
+ * While showing only the next level of children is wanted, when hiding ALL levels need to be hidden
+ * instead. This can not easily be achieved with the current markup placing ALL directories, files
+ * etc. regardless of their depth on the same level. So a special event is registered on each dir
+ * to simply hide ALL of it's own children and that event is triggered on ALL children of some dir
+ * as necessary.
+ * </p>
+ * @param[in] directChildren
+ * @return {@code false} to stop propagation of the current event.
+ */
+function recursiveLoadRowParentOnHideChildren(directChildren)
+{
+    $.each(directChildren, function()
+    {
+        $(this).hide();
+    });
+
+    return false;
+}
+
+/**
+ * Process one row when loading all directories and files of some repo recursively.
+ * <p>
+ * Markup currently doesn't proiperly model parent-child-relationships, so the current approach is
+ * to iterated all rows of some rendered table to find direct children on our own. Those children
+ * are the once to show or hide in the end any by iterating all rows and search the whole body for
+ * children, all of those can be found easily to register necessary event handlers.
+ * </p>
+ * @param[in] body
+ * @param[in] rowParent
+ */
+function recursiveLoadRowProc(body, rowParent)
+{
+    let directChildren = recursiveLoadDirectChildrenSelect(body, rowParent);
+
+    rowParent.on('click',           function() { return recursiveLoadRowParentOnClick(directChildren); });
+    rowParent.on('hide_children',   function() { return recursiveLoadRowParentOnHideChildren(directChildren);});
+}
+
+/**
+ * Register event handlers to hide and show children of root-directories.
+ */
 $('table#listing > tbody').each(function()
 {
     let body = $(this);
@@ -58,61 +193,5 @@ $('table#listing > tbody').each(function()
     // are maintained on the same level and only distinguished by their textual path. So we either
     // need to search the "tbody" per row for all children or implement some other approach mapping
     // things by only iterating rows once. The current approach seems easier for now.
-    body.children('tr').each(function()
-    {
-        let rowParent       = $(this);
-        let titleParent     = rowParent.attr('title') || '';
-        let selector        = 'tr[title^="' + titleParent + '/"]';
-        let directChildren  = [];
-
-        // Selectors don't support regular expressions, but direct children not only start with the
-        // parent, but don't contain additional children in their title as well. One can't select
-        // that condition easily, so find ALL children and filter later to direct ones only.
-        body.children(selector).each(function()
-        {
-            let rowChild    = $(this);
-            let titleChild  = rowChild.attr('title') || '';
-
-            // TODO \Q...\E doesn't work, pattern needs to be escaped properly somehow
-            // https://makandracards.com/makandra/15879-javascript-how-to-generate-a-regular-expression-from-a-string
-            let ptChildDirs     = titleParent + '/$';
-            let ptChildFiles    = titleParent + '/[^/]+$';
-            let pattern         = ptChildDirs + '|' + ptChildFiles;
-
-            if (titleChild.match(pattern))
-            {
-                directChildren.push(rowChild);
-            }
-        });
-
-        rowParent.on('click', function()
-        {
-            $.each(directChildren, function()
-            {
-                let self        = $(this);
-                let isVisible   = self.is(':visible');
-
-                if (!isVisible)
-                {
-                    self.show();
-                    return true;
-                }
-
-                self.trigger('hide_children');
-                self.hide();
-            });
-
-            return false;
-        });
-
-        rowParent.on('hide_children', function()
-        {
-            $.each(directChildren, function()
-            {
-                $(this).hide();
-            });
-
-            return false;
-        });
-    });
+    body.children('tr').each(function() { recursiveLoadRowProc(body, $(this)); });
 });

--- a/javascript/collapsible.js
+++ b/javascript/collapsible.js
@@ -78,6 +78,11 @@ $("tr").find("td.path").on("click",function(event)
         return;
     }
 
+    if ($target.children('a').children('img').attr('alt') == '[FILE]')
+    {
+        return;
+    }
+
     let strClassCheck = $target.closest("tr").next().attr("title");
     let resCheck = strClassCheck.split(" ");
     let performAction = $target.closest("tr").attr("customaction") == 'close'? 'open' : 'close';

--- a/javascript/collapsible.js
+++ b/javascript/collapsible.js
@@ -52,7 +52,8 @@ $("tbody > tr").each(function() {
     {
         $(this).attr("style","visibility: collapse");
     }
-    else {
+    else 
+    {
         strClass = $(this).attr("title");
         res = strClass.split(" ");
     }

--- a/listing.php
+++ b/listing.php
@@ -355,7 +355,6 @@ function showTreeDir($svnrep, $path, $rev, $peg, $listing) {
 
 // Make sure that we have a repository
 if ($rep) {
-	$start = microtime(true);
 	$svnrep = new SVNRepository($rep);
 
 	if (!empty($rev)) {
@@ -487,8 +486,6 @@ if ($rep) {
 		sendHeaderForbidden();
 	}
 	$vars['restricted'] = !$rep->hasReadAccess($path, false);
-	$time_elapsed_secs = microtime(true) - $start;
-	$vars['loadtimes'] = $time_elapsed_secs;
 } else {
 	http_response_code(404);
 }

--- a/listing.php
+++ b/listing.php
@@ -116,10 +116,13 @@ function showDirFiles($svnrep, $path, $rev, $peg, $listing, $index, $treeview = 
 					$listvar['node'] = $lastindexfile; // t-node
 					$listvar['level'] = ($treeview) ? $lastindexfile : 0;
 					$listvar['filename'] = $tempelements[$lastindexfile];
+					$listvar['classname'] = '';
 					for($n=0; $n<$lastindexfile; $n++)
 					{
 						$listvar['last_i_node'][$n] = false;
+						$listvar['classname'] = $listvar['classname'].$tempelements[$n].' ';
 					}
+					$listvar['classname'] = $listvar['classname'].$tempelements[$lastindexfile];
 					$listvar['last_i_node'][$lastindexfile] = true;
 				}
 				else
@@ -128,9 +131,11 @@ function showDirFiles($svnrep, $path, $rev, $peg, $listing, $index, $treeview = 
 					$listvar['node'] = $lastindexfile; // t-node
 					$listvar['level'] = ($treeview) ? $lastindexfile : 0;
 					$listvar['filename'] = $tempelements[$lastindexfile];
+					$listvar['classname'] = '';
 					for($n=0; $n<$lastindexfile; $n++)
 					{
 						$listvar['last_i_node'][$n] = false;
+						$listvar['classname'] = $listvar['classname'].$tempelements[$n].' ';
 					}
 					$listvar['last_i_node'][$lastindexfile] = true;
 				}

--- a/listing.php
+++ b/listing.php
@@ -50,22 +50,9 @@ function urlForPath($fullpath, $passRevString) {
 	return removeURLSeparator($url);
 }
 
-function showDirFiles($svnrep, $subs, $level, $limit, $rev, $peg, $listing, $index, $treeview = true) {
+function showDirFiles($svnrep, $path, $rev, $peg, $listing, $index, $treeview = true) {
 	global $config, $lang, $rep, $passrev, $peg, $passRevString;
 
-	$path = '';
-	
-	if (!$treeview) {
-		$level = $limit;
-	}
-	
-	// TODO: Fix node links to use the path and number of peg revision (if exists)
-	// This applies to file detail, log, and RSS -- leave the download link as-is
-	
-	for ($n = 0; $n <= $level; $n++) {
-		$path .= $subs[$n].'/';
-	}
-	
 	// List each file in the current directory
 	$loop = 0;
 	$last_index = 0;
@@ -101,9 +88,6 @@ function showDirFiles($svnrep, $subs, $level, $limit, $rev, $peg, $listing, $ind
 		foreach ($logList->entries as $entry) {
 			$isDir = $entry->isdir;
 			
-			if (!$isDir && $level != $limit) {
-				continue; // Skip any files outside the current directory
-			}
 			$file = $entry->file;
 			$isDirString = ($isDir) ? 'isdir=1&amp;' : '';
 
@@ -116,16 +100,14 @@ function showDirFiles($svnrep, $subs, $level, $limit, $rev, $peg, $listing, $ind
 				$listvar['rowparity'] = $index % 2;
 
 				if ($isDir) {
-					$listvar['filetype'] = ($openDir) ? 'diropen' : 'dir';
-					$openDir = isset($subs[$level + 1]) && (!strcmp($subs[$level + 1].'/', $file) || !strcmp($subs[$level + 1], $file));
+					$listvar['filetype'] = 'dir';
+					$openDir = true;
 				} else {
 					$listvar['filetype'] = strtolower(strrchr($file, '.'));
 					$openDir = false;
 				}
 				$listvar['isDir'] = $isDir;
 				$listvar['openDir'] = $openDir;
-				$listvar['level'] = ($treeview) ? $level : 0;
-				
 				$listvar['path'] = $path.$file;
 				$tempelements = explode('/',$file);
 				if ($tempelements[count($tempelements)-1] === "")
@@ -194,12 +176,11 @@ function showDirFiles($svnrep, $subs, $level, $limit, $rev, $peg, $listing, $ind
 
 function showTreeDir($svnrep, $path, $rev, $peg, $listing) {
 	global $vars, $config;
-	$subs = explode('/', $path);
 	// For directory, the last element in the subs is empty.
 	// For file, the last element in the subs is the file name.
 	// Therefore, it is always count($subs) - 2
 	$vars['compare_box'] = ''; // Set blank once in case tree view is not enabled.
-	return showDirFiles($svnrep, $subs, 0, 0, $rev, $peg, $listing, 0, $config->treeView);
+	return showDirFiles($svnrep, $path, $rev, $peg, $listing, 0, $config->treeView);
 }
 
 // Make sure that we have a repository

--- a/listing.php
+++ b/listing.php
@@ -235,7 +235,7 @@ function showAllDirFiles($svnrep, $path, $rev, $peg, $listing, $index, $treeView
 
 	foreach ($logList->entries as $entry) {
 		$isDir = $entry->isdir;
-		
+
 		$file = $entry->file;
 		$isDirString = ($isDir) ? 'isdir=1&amp;' : '';
 
@@ -360,21 +360,20 @@ function showTreeDir($svnrep, $path, $rev, $peg, $listing) {
 		$vars['compare_box'] = ''; // Set blank once in case tree view is not enabled.
 		return showAllDirFiles($svnrep, $path, $rev, $peg, $listing, 0, $config->treeView);
 	}
-	else {
-		$subs = explode('/', $path);
 
-		// For directory, the last element in the subs is empty.
-		// For file, the last element in the subs is the file name.
-		// Therefore, it is always count($subs) - 2
-		$limit = count($subs) - 2;
-	
-		for ($n = 0; $n < $limit; $n++) {
-			$vars['last_i_node'][$n] = false;
-		}
+	$subs = explode('/', $path);
 
-		$vars['compare_box'] = ''; // Set blank once in case tree view is not enabled.
-		return showDirFiles($svnrep, $subs, 0, $limit, $rev, $peg, $listing, 0, $config->treeView);
+	// For directory, the last element in the subs is empty.
+	// For file, the last element in the subs is the file name.
+	// Therefore, it is always count($subs) - 2
+	$limit = count($subs) - 2;
+
+	for ($n = 0; $n < $limit; $n++) {
+		$vars['last_i_node'][$n] = false;
 	}
+
+	$vars['compare_box'] = ''; // Set blank once in case tree view is not enabled.
+	return showDirFiles($svnrep, $subs, 0, $limit, $rev, $peg, $listing, 0, $config->treeView);
 }
 
 // Make sure that we have a repository

--- a/listing.php
+++ b/listing.php
@@ -124,9 +124,25 @@ function showDirFiles($svnrep, $subs, $level, $limit, $rev, $peg, $listing, $ind
 				$listvar['isDir'] = $isDir;
 				$listvar['openDir'] = $openDir;
 				$listvar['level'] = ($treeview) ? $level : 0;
-				$listvar['node'] = 0; // t-node
+				
 				$listvar['path'] = $path.$file;
-				$listvar['filename'] = escape($file);
+				$tempelements = explode('/',$file);
+				if ($tempelements[count($tempelements)-1] === "")
+				{
+					$lastindexfile = count($tempelements)-1 - 1;
+					$listvar['node'] = $lastindexfile; // t-node
+					$listvar['level'] = ($treeview) ? $lastindexfile : 0;
+					$listvar['filename'] = $tempelements[$lastindexfile];
+					//$listvar['filename'] = str_repeat('&nbsp;&nbsp;&nbsp;&nbsp;',$lastindexfile).$tempelements[$lastindexfile];
+				}
+				else
+				{
+					$lastindexfile = count($tempelements)-1;
+					$listvar['node'] = $lastindexfile; // t-node
+					$listvar['level'] = ($treeview) ? $lastindexfile : 0;
+					$listvar['filename'] = $tempelements[$lastindexfile];
+					//$listvar['filename'] = str_repeat('&nbsp;&nbsp;&nbsp;&nbsp;',$lastindexfile).$tempelements[$lastindexfile];
+				}
 				if ($isDir) {
 					$listvar['fileurl'] = urlForPath($path.$file, $passRevString);
 				} else {
@@ -171,23 +187,24 @@ function showDirFiles($svnrep, $subs, $level, $limit, $rev, $peg, $listing, $ind
 				$loop++;
 				$index++;
 				$last_index = $index;
-
+				/*
 				if ($isDir && ($level != $limit)) {
 					// @todo remove the alternate check with htmlentities when assured that there are not side effects
 					if (isset($subs[$level + 1]) && (!strcmp($subs[$level + 1].'/', $file) || !strcmp(htmlentities($subs[$level + 1], ENT_QUOTES).'/', htmlentities($file)))) {
 						$listing = showDirFiles($svnrep, $subs, $level + 1, $limit, $rev, $peg, $listing, $index);
 						$index = count($listing);
 					}
-				}
+				}*/
 			}
 		}
 	}
 
 	// For an expanded tree, give the last entry an "L" node to close the grouping
+	/*
 	if ($treeview && $last_index != 0) {
 		$listing[$last_index - 1]['node'] = 1; // l-node
 	}
-
+	*/
 	return $listing;
 }
 

--- a/listing.php
+++ b/listing.php
@@ -116,6 +116,11 @@ function showDirFiles($svnrep, $path, $rev, $peg, $listing, $index, $treeview = 
 					$listvar['node'] = $lastindexfile; // t-node
 					$listvar['level'] = ($treeview) ? $lastindexfile : 0;
 					$listvar['filename'] = $tempelements[$lastindexfile];
+					for($n=0; $n<$lastindexfile; $n++)
+					{
+						$listvar['last_i_node'][$n] = false;
+					}
+					$listvar['last_i_node'][$lastindexfile] = true;
 				}
 				else
 				{
@@ -123,6 +128,11 @@ function showDirFiles($svnrep, $path, $rev, $peg, $listing, $index, $treeview = 
 					$listvar['node'] = $lastindexfile; // t-node
 					$listvar['level'] = ($treeview) ? $lastindexfile : 0;
 					$listvar['filename'] = $tempelements[$lastindexfile];
+					for($n=0; $n<$lastindexfile; $n++)
+					{
+						$listvar['last_i_node'][$n] = false;
+					}
+					$listvar['last_i_node'][$lastindexfile] = true;
 				}
 				if ($isDir) {
 					$listvar['fileurl'] = urlForPath($path.$file, $passRevString);

--- a/listing.php
+++ b/listing.php
@@ -191,7 +191,7 @@ function showDirFiles($svnrep, $subs, $level, $limit, $rev, $peg, $listing, $ind
 	return $listing;
 }
 
-function showAllDirFiles($svnrep, $path, $rev, $peg, $listing, $index, $treeview = true) {
+function showAllDirFiles($svnrep, $path, $rev, $peg, $listing, $index, $treeView = true) {
 	global $config, $lang, $rep, $passrev, $peg, $passRevString;
 
 	// List each file in the current directory
@@ -200,10 +200,11 @@ function showAllDirFiles($svnrep, $path, $rev, $peg, $listing, $index, $treeview
 	$accessToThisDir = $rep->hasReadAccess($path, false);
 
 	// If using flat view and not at the root, create a '..' entry at the top.
-	if (!$treeview && count($subs) > 2) {
+	if (!$treeView && count($subs) > 2) {
 		$parentPath = $subs;
 		unset($parentPath[count($parentPath) - 2]);
 		$parentPath = implode('/', $parentPath);
+
 		if ($rep->hasReadAccess($parentPath, false)) {
 			$listvar = &$listing[$index];
 			$listvar['rowparity'] = $index % 2;
@@ -222,117 +223,140 @@ function showAllDirFiles($svnrep, $path, $rev, $peg, $listing, $index, $treeview
 			$index++;
 		}
 	}
+
 	$openDir = false;
 	$logList = $svnrep->getList($path, $rev, $peg);
-	if ($logList) {
-		$downloadRevAndPeg = createRevAndPegString($rev, $peg ? $peg : $rev);
-		foreach ($logList->entries as $entry) {
-			$isDir = $entry->isdir;
-			
-			$file = $entry->file;
-			$isDirString = ($isDir) ? 'isdir=1&amp;' : '';
 
-			// Only list files/directories that are not designated as off-limits
-			$access = ($isDir)	? $rep->hasReadAccess($path.$file, false)
-								: $accessToThisDir;
-
-			if ($access) {
-				$listvar = &$listing[$index];
-				$listvar['rowparity'] = $index % 2;
-
-				if ($isDir) {
-					$listvar['filetype'] = 'dir';
-					$openDir = true;
-				} else {
-					$listvar['filetype'] = strtolower(strrchr($file, '.'));
-					$openDir = false;
-				}
-				$listvar['isDir'] = $isDir;
-				$listvar['openDir'] = $openDir;
-				$listvar['path'] = $path.$file;
-				$tempelements = explode('/',$file);
-				if ($tempelements[count($tempelements)-1] === "")
-				{
-					$lastindexfile = count($tempelements)-1 - 1;
-					$listvar['node'] = $lastindexfile; // t-node
-					$listvar['level'] = ($treeview) ? $lastindexfile : 0;
-					$listvar['filename'] = $tempelements[$lastindexfile];
-					$listvar['classname'] = '';
-					for($n=0; $n<$lastindexfile; $n++)
-					{
-						$listvar['last_i_node'][$n] = false;
-						$listvar['classname'] = $listvar['classname'].$tempelements[$n].' ';
-					}
-					$listvar['classname'] = $listvar['classname'].$tempelements[$lastindexfile];
-					$listvar['last_i_node'][$lastindexfile] = true;
-				}
-				else
-				{
-					$lastindexfile = count($tempelements)-1;
-					$listvar['node'] = $lastindexfile; // t-node
-					$listvar['level'] = ($treeview) ? $lastindexfile : 0;
-					$listvar['filename'] = $tempelements[$lastindexfile];
-					$listvar['classname'] = '';
-					for($n=0; $n<$lastindexfile; $n++)
-					{
-						$listvar['last_i_node'][$n] = false;
-						$listvar['classname'] = $listvar['classname'].$tempelements[$n].' ';
-					}
-					$listvar['last_i_node'][$lastindexfile] = true;
-				}
-				if ($isDir) {
-					$listvar['fileurl'] = urlForPath($path.$file, $passRevString);
-				} else {
-					$listvar['fileurl'] = urlForPath($path.$file, createDifferentRevAndPegString($passrev, $peg));
-				}
-				$listvar['filelink'] = '<a href="'.$listvar['fileurl'].'">'.$listvar['filename'].'</a>';
-				if ($isDir) {
-					$listvar['logurl'] = $config->getURL($rep, $path.$file, 'log').$isDirString.$passRevString;
-				} else {
-					$listvar['logurl'] = $config->getURL($rep, $path.$file, 'log').$isDirString.createDifferentRevAndPegString($passrev, $peg);
-				}
-
-				if ($treeview) {
-					$listvar['compare_box'] = '<input type="checkbox" name="compare[]" value="'.escape($path.$file).'@'.$passrev.'" onclick="enforceOnlyTwoChecked(this)" />';
-				}
-				if ($config->showLastModInListing()) {
-					$listvar['committime'] = $entry->committime;
-					$listvar['revision'] = $entry->rev;
-					$listvar['author'] = $entry->author;
-					$listvar['age'] = $entry->age;
-					$listvar['date'] = $entry->date;
-					$listvar['revurl'] = $config->getURL($rep, $path.$file, 'revision').$isDirString.createRevAndPegString($entry->rev, $peg ? $peg : $rev);
-				}
-				if ($rep->isDownloadAllowed($path.$file)) {
-					$downloadurl = $config->getURL($rep, $path.$file, 'dl').$isDirString.$downloadRevAndPeg;
-					if ($isDir) {
-						$listvar['downloadurl'] = $downloadurl;
-						$listvar['downloadplainurl'] = '';
-					} else {
-						$listvar['downloadplainurl'] = $downloadurl;
-						$listvar['downloadurl'] = '';
-					}
-				} else {
-					$listvar['downloadplainurl'] = '';
-					$listvar['downloadurl'] = '';
-				}
-				if ($rep->isRssEnabled()) {
-					// RSS should always point to the latest revision, so don't include rev
-					$listvar['rssurl'] = $config->getURL($rep, $path.$file, 'rss').$isDirString.createRevAndPegString('', $peg);
-				}
-
-				$loop++;
-				$index++;
-				$last_index = $index;
-			}
-		}
+	if (!$logList) {
+		return $listing;
 	}
+
+	$downloadRevAndPeg = createRevAndPegString($rev, $peg ? $peg : $rev);
+
+	foreach ($logList->entries as $entry) {
+		$isDir = $entry->isdir;
+		
+		$file = $entry->file;
+		$isDirString = ($isDir) ? 'isdir=1&amp;' : '';
+
+		// Only list files/directories that are not designated as off-limits
+		$access = ($isDir)	? $rep->hasReadAccess($path.$file, false)
+							: $accessToThisDir;
+
+		if (!$access) {
+			continue;
+		}
+
+		$listvar = &$listing[$index];
+		$listvar['rowparity'] = $index % 2;
+
+		if ($isDir) {
+			$listvar['filetype'] = 'dir';
+			$openDir = true;
+		} else {
+			$listvar['filetype'] = strtolower(strrchr($file, '.'));
+			$openDir = false;
+		}
+
+		$listvar['isDir'] = $isDir;
+		$listvar['openDir'] = $openDir;
+		$listvar['path'] = $path.$file;
+		$tempelements = explode('/',$file);
+
+		if ($tempelements[count($tempelements)-1] === "")
+		{
+			$lastindexfile = count($tempelements)-1 - 1;
+			$listvar['node'] = $lastindexfile; // t-node
+			$listvar['level'] = ($treeView) ? $lastindexfile : 0;
+			$listvar['filename'] = $tempelements[$lastindexfile];
+			$listvar['classname'] = '';
+
+			for($n=0; $n<$lastindexfile; $n++)
+			{
+				$listvar['last_i_node'][$n] = false;
+				$listvar['classname'] = $listvar['classname'].$tempelements[$n].' ';
+			}
+
+			$listvar['classname'] = $listvar['classname'].$tempelements[$lastindexfile];
+			$listvar['last_i_node'][$lastindexfile] = true;
+		}
+		else
+		{
+			$lastindexfile = count($tempelements)-1;
+			$listvar['node'] = $lastindexfile; // t-node
+			$listvar['level'] = ($treeView) ? $lastindexfile : 0;
+			$listvar['filename'] = $tempelements[$lastindexfile];
+			$listvar['classname'] = '';
+
+			for($n=0; $n<$lastindexfile; $n++)
+			{
+				$listvar['last_i_node'][$n] = false;
+				$listvar['classname'] = $listvar['classname'].$tempelements[$n].' ';
+			}
+
+			$listvar['last_i_node'][$lastindexfile] = true;
+		}
+
+		if ($isDir) {
+			$listvar['fileurl'] = urlForPath($path.$file, $passRevString);
+		} else {
+			$listvar['fileurl'] = urlForPath($path.$file, createDifferentRevAndPegString($passrev, $peg));
+		}
+
+		$listvar['filelink'] = '<a href="'.$listvar['fileurl'].'">'.$listvar['filename'].'</a>';
+
+		if ($isDir) {
+			$listvar['logurl'] = $config->getURL($rep, $path.$file, 'log').$isDirString.$passRevString;
+		} else {
+			$listvar['logurl'] = $config->getURL($rep, $path.$file, 'log').$isDirString.createDifferentRevAndPegString($passrev, $peg);
+		}
+
+		if ($treeView) {
+			$listvar['compare_box'] = '<input type="checkbox" name="compare[]" value="'.escape($path.$file).'@'.$passrev.'" onclick="enforceOnlyTwoChecked(this)" />';
+		}
+
+		if ($config->showLastModInListing()) {
+			$listvar['committime'] = $entry->committime;
+			$listvar['revision'] = $entry->rev;
+			$listvar['author'] = $entry->author;
+			$listvar['age'] = $entry->age;
+			$listvar['date'] = $entry->date;
+			$listvar['revurl'] = $config->getURL($rep, $path.$file, 'revision').$isDirString.createRevAndPegString($entry->rev, $peg ? $peg : $rev);
+		}
+
+		if ($rep->isDownloadAllowed($path.$file)) {
+			$downloadurl = $config->getURL($rep, $path.$file, 'dl').$isDirString.$downloadRevAndPeg;
+
+			if ($isDir) {
+				$listvar['downloadurl'] = $downloadurl;
+				$listvar['downloadplainurl'] = '';
+			} else {
+				$listvar['downloadplainurl'] = $downloadurl;
+				$listvar['downloadurl'] = '';
+			}
+		} else {
+			$listvar['downloadplainurl'] = '';
+			$listvar['downloadurl'] = '';
+		}
+
+		if ($rep->isRssEnabled()) {
+			// RSS should always point to the latest revision, so don't include rev
+			$listvar['rssurl'] = $config->getURL($rep, $path.$file, 'rss').$isDirString.createRevAndPegString('', $peg);
+		}
+
+		$loop++;
+		$index++;
+		$last_index = $index;
+
+	}
+
 	return $listing;
 }
 
 function showTreeDir($svnrep, $path, $rev, $peg, $listing) {
 	global $vars, $config;
-	if ($config->showLoadAllRepository()) {
+
+	if ($config->showLoadAllRepos()) {
 		$vars['compare_box'] = ''; // Set blank once in case tree view is not enabled.
 		return showAllDirFiles($svnrep, $path, $rev, $peg, $listing, 0, $config->treeView);
 	}
@@ -478,7 +502,7 @@ if ($rep) {
 
 	$vars['showlastmod'] = $config->showLastModInListing();
 
-	$vars['loadalldir'] = $config->showLoadAllRepository();
+	$vars['loadalldir'] = $config->showLoadAllRepos();
 	$listing = showTreeDir($svnrep, $path, $rev, $peg, array());
 
 	if (!$rep->hasReadAccess($path)) {

--- a/listing.php
+++ b/listing.php
@@ -54,17 +54,18 @@ function showDirFiles($svnrep, $subs, $level, $limit, $rev, $peg, $listing, $ind
 	global $config, $lang, $rep, $passrev, $peg, $passRevString;
 
 	$path = '';
-
+	
 	if (!$treeview) {
 		$level = $limit;
 	}
-
+	
 	// TODO: Fix node links to use the path and number of peg revision (if exists)
 	// This applies to file detail, log, and RSS -- leave the download link as-is
+	
 	for ($n = 0; $n <= $level; $n++) {
 		$path .= $subs[$n].'/';
 	}
-
+	
 	// List each file in the current directory
 	$loop = 0;
 	$last_index = 0;
@@ -93,13 +94,13 @@ function showDirFiles($svnrep, $subs, $level, $limit, $rev, $peg, $listing, $ind
 			$index++;
 		}
 	}
-
 	$openDir = false;
 	$logList = $svnrep->getList($path, $rev, $peg);
 	if ($logList) {
 		$downloadRevAndPeg = createRevAndPegString($rev, $peg ? $peg : $rev);
 		foreach ($logList->entries as $entry) {
 			$isDir = $entry->isdir;
+			
 			if (!$isDir && $level != $limit) {
 				continue; // Skip any files outside the current directory
 			}
@@ -133,7 +134,6 @@ function showDirFiles($svnrep, $subs, $level, $limit, $rev, $peg, $listing, $ind
 					$listvar['node'] = $lastindexfile; // t-node
 					$listvar['level'] = ($treeview) ? $lastindexfile : 0;
 					$listvar['filename'] = $tempelements[$lastindexfile];
-					//$listvar['filename'] = str_repeat('&nbsp;&nbsp;&nbsp;&nbsp;',$lastindexfile).$tempelements[$lastindexfile];
 				}
 				else
 				{
@@ -141,7 +141,6 @@ function showDirFiles($svnrep, $subs, $level, $limit, $rev, $peg, $listing, $ind
 					$listvar['node'] = $lastindexfile; // t-node
 					$listvar['level'] = ($treeview) ? $lastindexfile : 0;
 					$listvar['filename'] = $tempelements[$lastindexfile];
-					//$listvar['filename'] = str_repeat('&nbsp;&nbsp;&nbsp;&nbsp;',$lastindexfile).$tempelements[$lastindexfile];
 				}
 				if ($isDir) {
 					$listvar['fileurl'] = urlForPath($path.$file, $passRevString);
@@ -187,43 +186,20 @@ function showDirFiles($svnrep, $subs, $level, $limit, $rev, $peg, $listing, $ind
 				$loop++;
 				$index++;
 				$last_index = $index;
-				/*
-				if ($isDir && ($level != $limit)) {
-					// @todo remove the alternate check with htmlentities when assured that there are not side effects
-					if (isset($subs[$level + 1]) && (!strcmp($subs[$level + 1].'/', $file) || !strcmp(htmlentities($subs[$level + 1], ENT_QUOTES).'/', htmlentities($file)))) {
-						$listing = showDirFiles($svnrep, $subs, $level + 1, $limit, $rev, $peg, $listing, $index);
-						$index = count($listing);
-					}
-				}*/
 			}
 		}
 	}
-
-	// For an expanded tree, give the last entry an "L" node to close the grouping
-	/*
-	if ($treeview && $last_index != 0) {
-		$listing[$last_index - 1]['node'] = 1; // l-node
-	}
-	*/
 	return $listing;
 }
 
 function showTreeDir($svnrep, $path, $rev, $peg, $listing) {
 	global $vars, $config;
-
 	$subs = explode('/', $path);
-
 	// For directory, the last element in the subs is empty.
 	// For file, the last element in the subs is the file name.
 	// Therefore, it is always count($subs) - 2
-	$limit = count($subs) - 2;
-
-	for ($n = 0; $n < $limit; $n++) {
-		$vars['last_i_node'][$n] = false;
-	}
-
 	$vars['compare_box'] = ''; // Set blank once in case tree view is not enabled.
-	return showDirFiles($svnrep, $subs, 0, $limit, $rev, $peg, $listing, 0, $config->treeView);
+	return showDirFiles($svnrep, $subs, 0, 0, $rev, $peg, $listing, 0, $config->treeView);
 }
 
 // Make sure that we have a repository

--- a/listing.php
+++ b/listing.php
@@ -271,10 +271,10 @@ function showAllDirFiles($svnrep, $path, $rev, $peg, $listing, $index, $treeView
 			$listvar['filename'] = $tempelements[$lastindexfile];
 			$listvar['classname'] = '';
 
-			for($n=0; $n<$lastindexfile; $n++)
+			for ($n = 0; $n < $lastindexfile; ++$n)
 			{
-				$listvar['last_i_node'][$n] = false;
-				$listvar['classname'] = $listvar['classname'].$tempelements[$n].' ';
+				$listvar['last_i_node'][$n]	= false;
+				$listvar['classname']		= $listvar['classname'].$tempelements[$n].'/';
 			}
 
 			$listvar['classname'] = $listvar['classname'].$tempelements[$lastindexfile];
@@ -288,10 +288,10 @@ function showAllDirFiles($svnrep, $path, $rev, $peg, $listing, $index, $treeView
 			$listvar['filename'] = $tempelements[$lastindexfile];
 			$listvar['classname'] = '';
 
-			for($n=0; $n<$lastindexfile; $n++)
+			for ($n=0; $n < $lastindexfile; ++$n)
 			{
-				$listvar['last_i_node'][$n] = false;
-				$listvar['classname'] = $listvar['classname'].$tempelements[$n].' ';
+				$listvar['last_i_node'][$n]	= false;
+				$listvar['classname']		= $listvar['classname'].$tempelements[$n].'/';
 			}
 
 			$listvar['last_i_node'][$lastindexfile] = true;

--- a/templates/BlueGrey/directory.tmpl
+++ b/templates/BlueGrey/directory.tmpl
@@ -86,8 +86,8 @@ e-node=<img class="icon" border="0" width="24" height="22" src="[websvn:locwebsv
         </tr>
         </thead>
       [websvn-startlisting]
-        <tr class="row[websvn:rowparity]">
-          <td valign="middle">
+        <tr class="row[websvn:rowparity]" [websvn-test:loadalldir]customaction="closed" title="[websvn:classname]"[websvn-endtest]>
+          <td class="path" valign="middle">
             [websvn:compare_box]
             [websvn-treenode]
             [websvn-icon]
@@ -123,5 +123,14 @@ e-node=<img class="icon" border="0" width="24" height="22" src="[websvn:locwebsv
       [websvn-endlisting]
       </table>
     [websvn:compare_submit][websvn:compare_endform]
+  [websvn-endtest]
+  [websvn-test:loadalldir]
+  <script type="text/javascript" src="[websvn:locwebsvnhttp]/javascript/jquery.min.1.9.1.js"></script>
+  <script type="text/javascript" src="[websvn:locwebsvnhttp]/javascript/collapsible.js"></script>
+      <script type="text/javascript">
+      //<![CDATA[
+      collapseAllDir();
+      //]]>
+      </script>
   [websvn-endtest]
 [websvn-endtest]

--- a/templates/BlueGrey/directory.tmpl
+++ b/templates/BlueGrey/directory.tmpl
@@ -85,6 +85,7 @@ e-node=<img class="icon" border="0" width="24" height="22" src="[websvn:locwebsv
         [websvn-endtest]
         </tr>
         </thead>
+        <tbody>
       [websvn-startlisting]
         <tr class="row[websvn:rowparity]" 
           [websvn-test:loadalldir]
@@ -125,16 +126,12 @@ e-node=<img class="icon" border="0" width="24" height="22" src="[websvn:locwebsv
           [websvn-endtest]
         </tr>
       [websvn-endlisting]
+      </tbody>
       </table>
     [websvn:compare_submit][websvn:compare_endform]
   [websvn-endtest]
   [websvn-test:loadalldir]
   <script type="text/javascript" src="[websvn:locwebsvnhttp]/javascript/jquery.min.1.9.1.js"></script>
   <script type="text/javascript" src="[websvn:locwebsvnhttp]/javascript/collapsible.js"></script>
-      <script type="text/javascript">
-      //<![CDATA[
-      collapseAllDir();
-      //]]>
-      </script>
   [websvn-endtest]
 [websvn-endtest]

--- a/templates/BlueGrey/directory.tmpl
+++ b/templates/BlueGrey/directory.tmpl
@@ -86,7 +86,11 @@ e-node=<img class="icon" border="0" width="24" height="22" src="[websvn:locwebsv
         </tr>
         </thead>
       [websvn-startlisting]
-        <tr class="row[websvn:rowparity]" [websvn-test:loadalldir]customaction="closed" title="[websvn:classname]"[websvn-endtest]>
+        <tr class="row[websvn:rowparity]" 
+          [websvn-test:loadalldir]
+            customaction="close" title="[websvn:classname]"
+          [websvn-endtest]
+        >
           <td class="path" valign="middle">
             [websvn:compare_box]
             [websvn-treenode]

--- a/templates/BlueGrey/directory.tmpl
+++ b/templates/BlueGrey/directory.tmpl
@@ -95,8 +95,10 @@ e-node=<img class="icon" border="0" width="24" height="22" src="[websvn:locwebsv
           <td class="path" valign="middle">
             [websvn:compare_box]
             [websvn-treenode]
-            [websvn-icon]
-            [websvn:filelink]
+            <a href="[websvn:fileurl]">
+                [websvn-icon]
+                [websvn:filename]
+            </a>
           </td>
           [websvn-test:showlastmod]
           <td class="rev"><a href="[websvn:revurl]">[websvn:revision]</a>&nbsp;</td>

--- a/templates/BlueGrey/directory.tmpl
+++ b/templates/BlueGrey/directory.tmpl
@@ -89,7 +89,7 @@ e-node=<img class="icon" border="0" width="24" height="22" src="[websvn:locwebsv
       [websvn-startlisting]
         <tr class="row[websvn:rowparity]" 
           [websvn-test:loadalldir]
-            customaction="close" title="[websvn:classname]"
+            title="[websvn:classname]"
           [websvn-endtest]
         >
           <td class="path" valign="middle">

--- a/templates/Elegant/directory.tmpl
+++ b/templates/Elegant/directory.tmpl
@@ -141,10 +141,5 @@ e-node=<img src="[websvn:locwebsvnhttp]/templates/Elegant/images/blank.png" alt=
     [websvn-test:loadalldir]
     <script type="text/javascript" src="[websvn:locwebsvnhttp]/javascript/jquery.min.1.9.1.js"></script>
     <script type="text/javascript" src="[websvn:locwebsvnhttp]/javascript/collapsible.js"></script>
-        <script type="text/javascript">
-        //<![CDATA[
-        collapseAllDir();
-        //]]>
-        </script>
     [websvn-endtest]
   [websvn-endtest]

--- a/templates/Elegant/directory.tmpl
+++ b/templates/Elegant/directory.tmpl
@@ -93,7 +93,7 @@ e-node=<img src="[websvn:locwebsvnhttp]/templates/Elegant/images/blank.png" alt=
           [websvn-test:rowparity]
           <tr class="shaded" 
           [websvn-test:loadalldir]
-              customaction="close" title="[websvn:classname]"
+              title="[websvn:classname]"
           [websvn-endtest]
           >
           [websvn-else]

--- a/templates/Elegant/directory.tmpl
+++ b/templates/Elegant/directory.tmpl
@@ -61,8 +61,8 @@
 .php=<img src="[websvn:locwebsvnhttp]/templates/Elegant/images/file-php.png" alt="PHP file" />
 .css=<img src="[websvn:locwebsvnhttp]/templates/Elegant/images/file-css.png" alt="CSS file" />
 
-dir=<img src="[websvn:locwebsvnhttp]/templates/Elegant/images/directory.png" alt="directory" />
-diropen=<img src="[websvn:locwebsvnhttp]/templates/Elegant/images/directory.png" alt="directory" />
+dir=<img src="[websvn:locwebsvnhttp]/templates/Elegant/images/directory.png" alt="[DIRECTORY]" />
+diropen=<img src="[websvn:locwebsvnhttp]/templates/Elegant/images/directory.png" alt="[DIRECTORY]" />
 i-node=<img src="[websvn:locwebsvnhttp]/templates/Elegant/images/blank.png" alt="node" />
 t-node=<img src="[websvn:locwebsvnhttp]/templates/Elegant/images/blank.png" alt="node" />
 l-node=<img src="[websvn:locwebsvnhttp]/templates/Elegant/images/blank.png" alt="node" />
@@ -99,11 +99,13 @@ e-node=<img src="[websvn:locwebsvnhttp]/templates/Elegant/images/blank.png" alt=
           [websvn-else]
           <tr [websvn-test:loadalldir]customaction="closed" title="[websvn:classname]"[websvn-endtest]>
           [websvn-endtest]
-            <td class="path">
+            <td class="path" valign="middle">
               [websvn:compare_box]
               [websvn-treenode]
-              [websvn-icon]
-              [websvn:filelink]
+              <a href="[websvn:fileurl]">
+                [websvn-icon]
+                [websvn:filename]
+            </a>
             </td>
           [websvn-test:showlastmod]
             <td class="rev"><a href="[websvn:revurl]" title="[lang:REV] [websvn:revision]">[websvn:revision]</a>&nbsp;</td>

--- a/templates/Elegant/directory.tmpl
+++ b/templates/Elegant/directory.tmpl
@@ -91,9 +91,9 @@ e-node=<img src="[websvn:locwebsvnhttp]/templates/Elegant/images/blank.png" alt=
         <tbody>
         [websvn-startlisting]
           [websvn-test:rowparity]
-          <tr class="shaded">
+          <tr class="shaded" [websvn-test:loadalldir]customaction="closed" title="[websvn:classname]"[websvn-endtest]>
           [websvn-else]
-          <tr>
+          <tr [websvn-test:loadalldir]customaction="closed" title="[websvn:classname]"[websvn-endtest]>
           [websvn-endtest]
             <td class="path">
               [websvn:compare_box]
@@ -133,5 +133,14 @@ e-node=<img src="[websvn:locwebsvnhttp]/templates/Elegant/images/blank.png" alt=
       </table>
       <div id="compare-submit">[websvn:compare_submit]</div>
     [websvn:compare_endform]
+    [websvn-endtest]
+    [websvn-test:loadalldir]
+    <script type="text/javascript" src="[websvn:locwebsvnhttp]/javascript/jquery.min.1.9.1.js"></script>
+    <script type="text/javascript" src="[websvn:locwebsvnhttp]/javascript/collapsible.js"></script>
+        <script type="text/javascript">
+        //<![CDATA[
+        collapseAllDir();
+        //]]>
+        </script>
     [websvn-endtest]
   [websvn-endtest]

--- a/templates/Elegant/directory.tmpl
+++ b/templates/Elegant/directory.tmpl
@@ -91,7 +91,11 @@ e-node=<img src="[websvn:locwebsvnhttp]/templates/Elegant/images/blank.png" alt=
         <tbody>
         [websvn-startlisting]
           [websvn-test:rowparity]
-          <tr class="shaded" [websvn-test:loadalldir]customaction="closed" title="[websvn:classname]"[websvn-endtest]>
+          <tr class="shaded" 
+          [websvn-test:loadalldir]
+              customaction="close" title="[websvn:classname]"
+          [websvn-endtest]
+          >
           [websvn-else]
           <tr [websvn-test:loadalldir]customaction="closed" title="[websvn:classname]"[websvn-endtest]>
           [websvn-endtest]

--- a/templates/calm/directory.tmpl
+++ b/templates/calm/directory.tmpl
@@ -92,7 +92,7 @@ e-node=<img src="[websvn:locwebsvnhttp]/templates/calm/images/e-node.png" alt="[
       </thead>
       <tbody>
       [websvn-startlisting]
-      <tr class="row[websvn:rowparity]" valign="middle">
+      <tr class="row[websvn:rowparity]" customaction="closed" title="[websvn:classname]" valign="middle">
          <td class="path" valign="middle">
             [websvn:compare_box]
             [websvn-treenode]
@@ -138,4 +138,11 @@ e-node=<img src="[websvn:locwebsvnhttp]/templates/calm/images/e-node.png" alt="[
   [websvn:compare_endform]
 </div>
 [websvn-endtest]
+<script type="text/javascript" src="[websvn:locwebsvnhttp]/javascript/jquery.min.1.9.1.js"></script>
+<script type="text/javascript" src="[websvn:locwebsvnhttp]/javascript/collapsible.js"></script>
+    <script type="text/javascript">
+    //<![CDATA[
+    collapseAllDir();
+    //]]>
+    </script>
 [websvn-endtest]

--- a/templates/calm/directory.tmpl
+++ b/templates/calm/directory.tmpl
@@ -71,7 +71,7 @@ e-node=<img src="[websvn:locwebsvnhttp]/templates/calm/images/e-node.png" alt="[
 <div id="wrap">
 [websvn:compare_form]
   <div class="table-responsive">
-   <table>
+   <table id="listing">
       <thead>
       <tr align="left" valign="middle">
         <th scope="col" class="path">[lang:PATH]</th>

--- a/templates/calm/directory.tmpl
+++ b/templates/calm/directory.tmpl
@@ -94,8 +94,8 @@ e-node=<img src="[websvn:locwebsvnhttp]/templates/calm/images/e-node.png" alt="[
       [websvn-startlisting]
       <tr class="row[websvn:rowparity]" valign="middle"
             [websvn-test:loadalldir]
-                customaction="close" title="[websvn:classname]"
-            [websvn-endtest] 
+                title="[websvn:classname]"
+            [websvn-endtest]
         >
          <td class="path" valign="middle">
             [websvn:compare_box]

--- a/templates/calm/directory.tmpl
+++ b/templates/calm/directory.tmpl
@@ -145,10 +145,5 @@ e-node=<img src="[websvn:locwebsvnhttp]/templates/calm/images/e-node.png" alt="[
 [websvn-test:loadalldir]
 <script type="text/javascript" src="[websvn:locwebsvnhttp]/javascript/jquery.min.1.9.1.js"></script>
 <script type="text/javascript" src="[websvn:locwebsvnhttp]/javascript/collapsible.js"></script>
-    <script type="text/javascript">
-    //<![CDATA[
-    collapseAllDir();
-    //]]>
-    </script>
 [websvn-endtest]
 [websvn-endtest]

--- a/templates/calm/directory.tmpl
+++ b/templates/calm/directory.tmpl
@@ -92,7 +92,11 @@ e-node=<img src="[websvn:locwebsvnhttp]/templates/calm/images/e-node.png" alt="[
       </thead>
       <tbody>
       [websvn-startlisting]
-      <tr class="row[websvn:rowparity]" [websvn-test:loadalldir]customaction="closed" title="[websvn:classname]"[websvn-endtest] valign="middle">
+      <tr class="row[websvn:rowparity]" valign="middle"
+            [websvn-test:loadalldir]
+                customaction="close" title="[websvn:classname]"
+            [websvn-endtest] 
+        >
          <td class="path" valign="middle">
             [websvn:compare_box]
             [websvn-treenode]

--- a/templates/calm/directory.tmpl
+++ b/templates/calm/directory.tmpl
@@ -92,7 +92,7 @@ e-node=<img src="[websvn:locwebsvnhttp]/templates/calm/images/e-node.png" alt="[
       </thead>
       <tbody>
       [websvn-startlisting]
-      <tr class="row[websvn:rowparity]" customaction="closed" title="[websvn:classname]" valign="middle">
+      <tr class="row[websvn:rowparity]" [websvn-test:loadalldir]customaction="closed" title="[websvn:classname]"[websvn-endtest] valign="middle">
          <td class="path" valign="middle">
             [websvn:compare_box]
             [websvn-treenode]
@@ -138,6 +138,7 @@ e-node=<img src="[websvn:locwebsvnhttp]/templates/calm/images/e-node.png" alt="[
   [websvn:compare_endform]
 </div>
 [websvn-endtest]
+[websvn-test:loadalldir]
 <script type="text/javascript" src="[websvn:locwebsvnhttp]/javascript/jquery.min.1.9.1.js"></script>
 <script type="text/javascript" src="[websvn:locwebsvnhttp]/javascript/collapsible.js"></script>
     <script type="text/javascript">
@@ -145,4 +146,5 @@ e-node=<img src="[websvn:locwebsvnhttp]/templates/calm/images/e-node.png" alt="[
     collapseAllDir();
     //]]>
     </script>
+[websvn-endtest]
 [websvn-endtest]


### PR DESCRIPTION
I've had a look at #120 and sadly things didn't work for me: The click-handlers were wrong, using spaces to divide parts of paths broke with my test-repo containing dirs with spaces and depending on a proprietary attribute `customaction` didn't feel right as well, when we only wanted to toggle directories in the end. So I changed all of that and am providing current progress here.

Some things are still missing:

- [x] Remove `customaction` everywhere
- [X] Externalize large handler implementations to individual functions
- [X] Improve docs
- [X] Make regular expression safe to prevent injection

Possible improvements:

- [ ] Change icon of lowest directory without any further content to show it's empty? 
  - currently clicking -> no-op
  - no useful icons for all templates
- [x] Somehow detect if to apply new JS at all? 
  - `$config->setLoadAllRepos(true);`
- [ ] Apply sorting on row titles? 
  - `branches` vs. `branches/some_dir` vs. `branches/`, the latter containing a file
  - `branches/bfriedrich/Neu Textdokument[...]` vs. `index.js`

![Clipboard01](https://user-images.githubusercontent.com/6223655/93022949-157fb780-f5ec-11ea-90ea-1c4f748302e2.png)
![Clipboard02](https://user-images.githubusercontent.com/6223655/93022951-16184e00-f5ec-11ea-84fb-c39211e4d307.png)
![Clipboard03](https://user-images.githubusercontent.com/6223655/93022953-16184e00-f5ec-11ea-98fc-f5517aba2cf9.png)
![Clipboard04](https://user-images.githubusercontent.com/6223655/93022955-17497b00-f5ec-11ea-8b3a-b2f0ee3d228b.png)
![Clipboard05](https://user-images.githubusercontent.com/6223655/93051057-2bc95a00-f664-11ea-987b-65f0058c8bd9.png)
![Clipboard06](https://user-images.githubusercontent.com/6223655/93051066-2f5ce100-f664-11ea-80bf-e9cfee064885.png)

