### PR TITLE
Fix line breaks not appearing in commit messages in log view.

### DIFF
--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -930,7 +930,7 @@ class SVNRepository {
 		xml_set_character_data_handler($xml_parser, $charData);
 
 		for ($i = 0; $i < $linesCnt; ++$i) {
-			$line	= $lines[$i];
+			$line	= $lines[$i] . "\n";
 			$isLast	= $i == ($linesCnt - 1);
 
 			if (xml_parse($xml_parser, $line, $isLast)) {


### PR DESCRIPTION
Line break characters were being stripped before being passed to the
XML parser. This meant that commit messages with newlines in were
displayed as one ugly block of text.

I'm not sure, however, if this patch is the best way of fixing this.