### PR TITLE
Issue 126 - Attempt to show 404 with existing template error tag

### DIFF
--- a/blame.php
+++ b/blame.php
@@ -31,191 +31,235 @@ require_once 'include/template.php';
 $vars['action'] = $lang['BLAME'];
 
 // Make sure that we have a repository
-if ($rep) {
-	$svnrep = new SVNRepository($rep);
+if (!$rep)
+{
+	renderTemplateNoRepo('blame');
+}
 
-	// If there's no revision info, go to the lastest revision for this path
-	$history = $svnrep->getLog($path, 'HEAD', 1, false, 2, ($path == '/') ? '' : $peg);
-	if (!$history) {
-		unset($vars['error']);
-		$history = $svnrep->getLog($path, '', '', false, 2, ($path == '/') ? '' : $peg);
-		if (!$history) {
-			http_response_code(404);
-			$vars['error'] = $lang['NOPATH'];
+$svnrep = new SVNRepository($rep);
+
+// If there's no revision info, go to the lastest revision for this path
+$history = $svnrep->getLog($path, 'HEAD', 1, false, 2, ($path == '/') ? '' : $peg);
+
+if (!$history) 
+{
+	unset($vars['error']);
+	$history = $svnrep->getLog($path, '', '', false, 2, ($path == '/') ? '' : $peg);
+
+	if (!$history)
+	{
+		http_response_code(404);
+		$vars['error'] = $lang['NOPATH'];
+	}
+}
+$youngest = ($history && isset($history->entries[0])) ? $history->entries[0]->rev : false;
+
+if (empty($rev)) 
+{
+	$rev = $youngest;
+} 
+else 
+{
+	$history = $svnrep->getLog($path, $rev, '', false, 2, $peg);
+
+	if (!$history) 
+	{
+		http_response_code(404);
+		$vars['error'] = $lang['NOPATH'];
+	}
+}
+
+if ($path[0] != '/') 
+{
+	$ppath = '/'.$path;
+} 
+else 
+{
+	$ppath = $path;
+}
+
+// Find the parent path (or the whole path if it's already a directory)
+$pos = strrpos($ppath, '/');
+$parent = substr($ppath, 0, $pos + 1);
+
+$vars['rev'] = $rev;
+$vars['peg'] = $peg;
+$vars['path'] = escape($ppath);
+
+if (isset($history->entries[0])) 
+{
+	$vars['log'] = xml_entities($history->entries[0]->msg);
+	$vars['date'] = $history->entries[0]->date;
+	$vars['age'] = datetimeFormatDuration(time() - strtotime($history->entries[0]->date));
+	$vars['author'] = $history->entries[0]->author;
+}
+
+createPathLinks($rep, $ppath, $passrev, $peg);
+$passRevString = createRevAndPegString($rev, $peg);
+
+if ($rev != $youngest) 
+{
+	$vars['goyoungesturl'] = $config->getURL($rep, $path, 'blame').createRevAndPegString('', $peg);
+	$vars['goyoungestlink'] = '<a href="'.$vars['goyoungesturl'].'"'.($youngest ? ' title="'.$lang['REV'].' '.$youngest.'"' : '').'>'.$lang['GOYOUNGEST'].'</a>';
+}
+
+$revurl = $config->getURL($rep, $path, 'blame');
+
+if ($rev < $youngest) 
+{
+	$history2 = $svnrep->getLog($path, $rev, $youngest, true, 2, $peg);
+
+	if (isset($history2->entries[1])) 
+	{
+		$nextRev = $history2->entries[1]->rev;
+		if ($nextRev != $youngest) 
+		{
+			$vars['nextrev'] = $nextRev;
+			$vars['nextrevurl'] = $revurl.createRevAndPegString($nextRev, $peg);
 		}
 	}
-	$youngest = ($history && isset($history->entries[0])) ? $history->entries[0]->rev : false;
 
-	if (empty($rev)) {
-		$rev = $youngest;
-	} else {
-		$history = $svnrep->getLog($path, $rev, '', false, 2, $peg);
-		if (!$history) {
-			http_response_code(404);
-			$vars['error'] = $lang['NOPATH'];
-		}
-	}
+	unset($vars['error']);
+}
 
-	if ($path[0] != '/') {
-		$ppath = '/'.$path;
-	} else {
-		$ppath = $path;
-	}
+if (isset($history->entries[1])) 
+{
+	$prevRev = $history->entries[1]->rev;
+	$prevPath = $history->entries[1]->path;
+	$vars['prevrev'] = $prevRev;
+	$vars['prevrevurl'] = $revurl.createRevAndPegString($prevRev, $peg);
+}
 
-	// Find the parent path (or the whole path if it's already a directory)
-	$pos = strrpos($ppath, '/');
-	$parent = substr($ppath, 0, $pos + 1);
+$vars['revurl'] = $config->getURL($rep, $path, 'revision').$passRevString;
+$vars['revlink'] = '<a href="'.$vars['revurl'].'">'.$lang['LASTMOD'].'</a>';
 
-	$vars['rev'] = $rev;
-	$vars['peg'] = $peg;
-	$vars['path'] = escape($ppath);
+$vars['logurl'] = $config->getURL($rep, $path, 'log').$passRevString;
+$vars['loglink'] = '<a href="'.$vars['logurl'].'">'.$lang['VIEWLOG'].'</a>';
 
-	if (isset($history->entries[0])) {
-		$vars['log'] = xml_entities($history->entries[0]->msg);
-		$vars['date'] = $history->entries[0]->date;
-		$vars['age'] = datetimeFormatDuration(time() - strtotime($history->entries[0]->date));
-		$vars['author'] = $history->entries[0]->author;
-	}
+$vars['filedetailurl'] = $config->getURL($rep, $path, 'file').$passRevString;
+$vars['filedetaillink'] = '<a href="'.$vars['filedetailurl'].'">'.$lang['FILEDETAIL'].'</a>';
 
-	createPathLinks($rep, $ppath, $passrev, $peg);
-	$passRevString = createRevAndPegString($rev, $peg);
+if ($history == null || count($history->entries) > 1) 
+{
+	$vars['diffurl'] = $config->getURL($rep, $path, 'diff').$passRevString;
+	$vars['difflink'] = '<a href="'.$vars['diffurl'].'">'.$lang['DIFFPREV'].'</a>';
+}
 
-	if ($rev != $youngest) {
-		$vars['goyoungesturl'] = $config->getURL($rep, $path, 'blame').createRevAndPegString('', $peg);
-		$vars['goyoungestlink'] = '<a href="'.$vars['goyoungesturl'].'"'.($youngest ? ' title="'.$lang['REV'].' '.$youngest.'"' : '').'>'.$lang['GOYOUNGEST'].'</a>';
-	}
+if ($rep->isRssEnabled()) 
+{
+	$vars['rssurl'] = $config->getURL($rep, $path, 'rss').createRevAndPegString('', $peg);
+	$vars['rsslink'] = '<a href="'.$vars['rssurl'].'">'.$lang['RSSFEED'].'</a>';
+}
 
-	$revurl = $config->getURL($rep, $path, 'blame');
-	if ($rev < $youngest) {
-		$history2 = $svnrep->getLog($path, $rev, $youngest, true, 2, $peg);
-		if (isset($history2->entries[1])) {
-			$nextRev = $history2->entries[1]->rev;
-			if ($nextRev != $youngest) {
-				$vars['nextrev'] = $nextRev;
-				$vars['nextrevurl'] = $revurl.createRevAndPegString($nextRev, $peg);
-			}
-		}
-		unset($vars['error']);
-	}
+// Check for binary file type before grabbing blame information.
+$svnMimeType = $svnrep->getProperty($path, 'svn:mime-type', $rev, $peg);
 
-	if (isset($history->entries[1])) {
-		$prevRev = $history->entries[1]->rev;
-		$prevPath = $history->entries[1]->path;
-		$vars['prevrev'] = $prevRev;
-		$vars['prevrevurl'] = $revurl.createRevAndPegString($prevRev, $peg);
-	}
+if (!$rep->getIgnoreSvnMimeTypes() && preg_match('~application/*~', $svnMimeType)) 
+{
+	$vars['warning'] = 'Cannot display blame info for binary file. (svn:mime-type = '.$svnMimeType.')';
+	$vars['javascript'] = '';
+}
+else 
+{
+	// Get the contents of the file
+	$tfname = tempnamWithCheck($config->getTempDir(), '');
+	$highlighted = $svnrep->getFileContents($path, $tfname, $rev, $peg, '', 'line');
 
-	$vars['revurl'] = $config->getURL($rep, $path, 'revision').$passRevString;
-	$vars['revlink'] = '<a href="'.$vars['revurl'].'">'.$lang['LASTMOD'].'</a>';
+	if ($file = fopen($tfname, 'r')) 
+	{
+		// Get the blame info
+		$tbname = tempnamWithCheck($config->getTempDir(), '');
 
-	$vars['logurl'] = $config->getURL($rep, $path, 'log').$passRevString;
-	$vars['loglink'] = '<a href="'.$vars['logurl'].'">'.$lang['VIEWLOG'].'</a>';
+		$svnrep->getBlameDetails($path, $tbname, $rev, $peg);
 
-	$vars['filedetailurl'] = $config->getURL($rep, $path, 'file').$passRevString;
-	$vars['filedetaillink'] = '<a href="'.$vars['filedetailurl'].'">'.$lang['FILEDETAIL'].'</a>';
+		if ($blame = fopen($tbname, 'r')) 
+		{
+			// Create an array of version/author/line
 
-	if ($history == null || count($history->entries) > 1) {
-		$vars['diffurl'] = $config->getURL($rep, $path, 'diff').$passRevString;
-		$vars['difflink'] = '<a href="'.$vars['diffurl'].'">'.$lang['DIFFPREV'].'</a>';
-	}
+			$index = 0;
+			$seen_rev = array();
+			$last_rev = '';
+			$row_class = '';
 
-	if ($rep->isRssEnabled()) {
-		$vars['rssurl'] = $config->getURL($rep, $path, 'rss').createRevAndPegString('', $peg);
-		$vars['rsslink'] = '<a href="'.$vars['rssurl'].'">'.$lang['RSSFEED'].'</a>';
-	}
+			while (!feof($blame) && !feof($file)) 
+			{
+				$blameline = fgets($blame);
 
-	// Check for binary file type before grabbing blame information.
-	$svnMimeType = $svnrep->getProperty($path, 'svn:mime-type', $rev, $peg);
+				if ($blameline != '') 
+				{
+					list($revision, $author, $remainder) = sscanf($blameline, '%d %s %s');
+					$empty = !$remainder;
 
-	if (!$rep->getIgnoreSvnMimeTypes() && preg_match('~application/*~', $svnMimeType)) {
-		$vars['warning'] = 'Cannot display blame info for binary file. (svn:mime-type = '.$svnMimeType.')';
-		$vars['javascript'] = '';
-	} else {
-		// Get the contents of the file
-		$tfname = tempnamWithCheck($config->getTempDir(), '');
-		$highlighted = $svnrep->getFileContents($path, $tfname, $rev, $peg, '', 'line');
+					$listvar = &$listing[$index];
+					$listvar['lineno'] = $index + 1;
 
-		if ($file = fopen($tfname, 'r')) {
-			// Get the blame info
-			$tbname = tempnamWithCheck($config->getTempDir(), '');
-
-			$svnrep->getBlameDetails($path, $tbname, $rev, $peg);
-
-			if ($blame = fopen($tbname, 'r')) {
-				// Create an array of version/author/line
-
-				$index = 0;
-				$seen_rev = array();
-				$last_rev = '';
-				$row_class = '';
-
-				while (!feof($blame) && !feof($file)) {
-					$blameline = fgets($blame);
-
-					if ($blameline != '') {
-						list($revision, $author, $remainder) = sscanf($blameline, '%d %s %s');
-						$empty = !$remainder;
-
-						$listvar = &$listing[$index];
-						$listvar['lineno'] = $index + 1;
-
-						if ($last_rev != $revision) {
-							$listvar['revision'] = '<a id="l'.$index.'-rev" class="blame-revision" href="'.$config->getURL($rep, $path, 'blame').createRevAndPegString($revision, $peg ? $peg : $rev).'">'.$revision.'</a>';
-							$seen_rev[$revision] = 1;
-							$row_class = ($row_class == 'light') ? 'dark' : 'light';
-							$listvar['author'] = $author;
-						} else {
-							$listvar['revision'] = '';
-							$listvar['author'] = '';
-						}
-
-						$listvar['row_class'] = $row_class;
-						$last_rev = $revision;
-
-						$line = rtrim(fgets($file));
-						if (!$highlighted)
-							$line = escape(toOutputEncoding($line));
-						$listvar['line'] = ($empty) ? '&nbsp;' : wrapInCodeTagIfNecessary($line);
-						$index++;
+					if ($last_rev != $revision) 
+					{
+						$listvar['revision'] = '<a id="l'.$index.'-rev" class="blame-revision" href="'.$config->getURL($rep, $path, 'blame').createRevAndPegString($revision, $peg ? $peg : $rev).'">'.$revision.'</a>';
+						$seen_rev[$revision] = 1;
+						$row_class = ($row_class == 'light') ? 'dark' : 'light';
+						$listvar['author'] = $author;
+					} 
+					else 
+					{
+						$listvar['revision'] = '';
+						$listvar['author'] = '';
 					}
-				}
-				fclose($blame);
-			}
-			fclose($file);
-			@unlink($tbname);
-		}
-		@unlink($tfname);
 
-		// Build the necessary JavaScript as an array of lines, then join them with \n
-		$javascript = array();
-		$javascript[] = '<script type="text/javascript" src="'.$locwebsvnhttp.'/javascript/blame-popup.js"></script>';
-		$javascript[] = '<script type="text/javascript">';
-		$javascript[] = '/* <![CDATA[ */';
-		$javascript[] = 'var rev = new Array();';
+					$listvar['row_class'] = $row_class;
+					$last_rev = $revision;
 
-		ksort($seen_rev); // Sort revisions in descending order by key
-		if (empty($peg))
-			$peg = $rev;
-		if (!isset($vars['warning'])) {
-			foreach ($seen_rev as $key => $val) {
-				$history = $svnrep->getLog($path, $key, $key, false, 1, $peg);
-				if ($history) {
-					$javascript[] = 'rev['.$key.'] = \'<div class="date">'.$history->curEntry->date.'</div><div class="msg">'.addslashes(preg_replace('/\n/', ' ', $history->curEntry->msg)).'</div>\';';
+					$line = rtrim(fgets($file));
+					if (!$highlighted)
+					{
+						$line = escape(toOutputEncoding($line));
+					}
+					$listvar['line'] = ($empty) ? '&nbsp;' : wrapInCodeTagIfNecessary($line);
+					$index++;
 				}
 			}
+			fclose($blame);
 		}
-		$javascript[] = '/* ]]> */';
-		$javascript[] = '</script>';
-		$vars['javascript'] = implode("\n", $javascript);
+
+		fclose($file);
+		@unlink($tbname);
+	}
+	@unlink($tfname);
+
+	// Build the necessary JavaScript as an array of lines, then join them with \n
+	$javascript = array();
+	$javascript[] = '<script type="text/javascript" src="'.$locwebsvnhttp.'/javascript/blame-popup.js"></script>';
+	$javascript[] = '<script type="text/javascript">';
+	$javascript[] = '/* <![CDATA[ */';
+	$javascript[] = 'var rev = new Array();';
+
+	ksort($seen_rev); // Sort revisions in descending order by key
+	if (empty($peg))
+	{
+		$peg = $rev;
+	}
+	if (!isset($vars['warning'])) 
+	{
+		foreach ($seen_rev as $key => $val) 
+		{
+			$history = $svnrep->getLog($path, $key, $key, false, 1, $peg);
+
+			if ($history) 
+			{
+				$javascript[] = 'rev['.$key.'] = \'<div class="date">'.$history->curEntry->date.'</div><div class="msg">'.addslashes(preg_replace('/\n/', ' ', $history->curEntry->msg)).'</div>\';';
+			}
+		}
 	}
 
-	if (!$rep->hasReadAccess($path, false)) {
-		$vars['error'] = $lang['NOACCESS'];
-		sendHeaderForbidden();
-	}
+	$javascript[] = '/* ]]> */';
+	$javascript[] = '</script>';
+	$vars['javascript'] = implode("\n", $javascript);
+}
 
-} else {
-	http_response_code(404);
+if (!$rep->hasReadAccess($path, false)) 
+{
+	$vars['error'] = $lang['NOACCESS'];
+	sendHeaderForbidden();
 }
 
 renderTemplate('blame');

--- a/blame.php
+++ b/blame.php
@@ -33,7 +33,7 @@ $vars['action'] = $lang['BLAME'];
 // Make sure that we have a repository
 if (!$rep)
 {
-	renderTemplateNoRepo('blame');
+	renderTemplate404('blame',$lang['NOREP']);
 }
 
 $svnrep = new SVNRepository($rep);

--- a/blame.php
+++ b/blame.php
@@ -48,8 +48,7 @@ if (!$history)
 
 	if (!$history)
 	{
-		http_response_code(404);
-		$vars['error'] = $lang['NOPATH'];
+		renderTemplate404('blame',$lang['NOPATH']);
 	}
 }
 $youngest = ($history && isset($history->entries[0])) ? $history->entries[0]->rev : false;
@@ -61,11 +60,9 @@ if (empty($rev))
 else 
 {
 	$history = $svnrep->getLog($path, $rev, '', false, 2, $peg);
-
 	if (!$history) 
 	{
-		http_response_code(404);
-		$vars['error'] = $lang['NOPATH'];
+		renderTemplate404('blame',$lang['NOPATH']);
 	}
 }
 

--- a/blame.php
+++ b/blame.php
@@ -33,7 +33,7 @@ $vars['action'] = $lang['BLAME'];
 // Make sure that we have a repository
 if (!$rep)
 {
-	renderTemplate404('blame',$lang['NOREP']);
+	renderTemplate404('blame','NOREP');
 }
 
 $svnrep = new SVNRepository($rep);
@@ -48,7 +48,7 @@ if (!$history)
 
 	if (!$history)
 	{
-		renderTemplate404('blame',$lang['NOPATH']);
+		renderTemplate404('blame','NOPATH');
 	}
 }
 $youngest = ($history && isset($history->entries[0])) ? $history->entries[0]->rev : false;
@@ -62,7 +62,7 @@ else
 	$history = $svnrep->getLog($path, $rev, '', false, 2, $peg);
 	if (!$history) 
 	{
-		renderTemplate404('blame',$lang['NOPATH']);
+		renderTemplate404('blame','NOPATH');
 	}
 }
 

--- a/comp.php
+++ b/comp.php
@@ -40,7 +40,7 @@ function checkRevision($rev)
 // Make sure that we have a repository
 if (!$rep)
 {
-	renderTemplate404('compare',$lang['NOREP']);
+	renderTemplate404('compare','NOREP');
 }
 
 $svnrep = new SVNRepository($rep);
@@ -154,7 +154,7 @@ $vars['rev2'] = $rev2;
 $history1 = $svnrep->getLog($path1, $rev1, 0, false, 1);
 if (!$history1) 
 {
-	renderTemplate404('compare',$lang['NOPATH']);
+	renderTemplate404('compare','NOPATH');
 }
 else
 {
@@ -162,7 +162,7 @@ else
 
 	if (!$history2) 
 	{
-		renderTemplate404('compare',$lang['NOPATH']);
+		renderTemplate404('compare','NOPATH');
 	}
 }
 

--- a/comp.php
+++ b/comp.php
@@ -40,7 +40,7 @@ function checkRevision($rev)
 // Make sure that we have a repository
 if (!$rep)
 {
-	renderTemplateNoRepo('compare');
+	renderTemplate404('compare',$lang['NOREP']);
 }
 
 $svnrep = new SVNRepository($rep);

--- a/comp.php
+++ b/comp.php
@@ -154,8 +154,7 @@ $vars['rev2'] = $rev2;
 $history1 = $svnrep->getLog($path1, $rev1, 0, false, 1);
 if (!$history1) 
 {
-	http_response_code(404);
-	$vars['error'] = $lang['NOPATH'];
+	renderTemplate404('compare',$lang['NOPATH']);
 }
 else
 {
@@ -163,8 +162,7 @@ else
 
 	if (!$history2) 
 	{
-		http_response_code(404);
-		$vars['error'] = $lang['NOPATH'];
+		renderTemplate404('compare',$lang['NOPATH']);
 	}
 }
 

--- a/comp.php
+++ b/comp.php
@@ -28,495 +28,604 @@ require_once 'include/svnlook.php';
 require_once 'include/utils.php';
 require_once 'include/template.php';
 
-function checkRevision($rev) {
-	if (is_numeric($rev) && ((int)$rev > 0)) {
+function checkRevision($rev) 
+{
+	if (is_numeric($rev) && ((int)$rev > 0)) 
+	{
 		return $rev;
 	}
 	return 'HEAD';
 }
 
 // Make sure that we have a repository
-if ($rep) {
-	$svnrep = new SVNRepository($rep);
+if (!$rep)
+{
+	renderTemplateNoRepo('compare');
+}
 
-	// Retrieve the request information
-	$path1 = @$_REQUEST['compare'][0];
-	$path2 = @$_REQUEST['compare'][1];
-	$rev1 = (int)@$_REQUEST['compare_rev'][0];
-	$rev2 = (int)@$_REQUEST['compare_rev'][1];
-	$manualorder = (@$_REQUEST['manualorder'] == 1);
-	$ignoreWhitespace = $config->getIgnoreWhitespacesInDiff();
-	if (array_key_exists('ignorews', $_REQUEST)) {
-		$ignoreWhitespace = (bool)$_REQUEST['ignorews'];
-	}
-	// Some page links put the revision with the path...
-	if (strpos($path1, '@')) {
-		list($path1, $rev1) = explode('@', $path1);
-	} else if (strpos($path1, '@') === 0) {
-		// Something went wrong. The path is missing.
-		$rev1 = substr($path1, 1);
-		$path1 = '/';
-	}
-	if (strpos($path2, '@')) {
-		list($path2, $rev2) = explode('@', $path2);
-	} else if (strpos($path2, '@') === 0) {
-		$rev2 = substr($path2, 1);
-		$path2 = '/';
-	}
+$svnrep = new SVNRepository($rep);
 
-	$rev1 = checkRevision($rev1);
-	$rev2 = checkRevision($rev2);
+// Retrieve the request information
+$path1 = @$_REQUEST['compare'][0];
+$path2 = @$_REQUEST['compare'][1];
+$rev1 = (int)@$_REQUEST['compare_rev'][0];
+$rev2 = (int)@$_REQUEST['compare_rev'][1];
+$manualorder = (@$_REQUEST['manualorder'] == 1);
+$ignoreWhitespace = $config->getIgnoreWhitespacesInDiff();
 
-	// Choose a sensible comparison order unless told not to
+if (array_key_exists('ignorews', $_REQUEST)) 
+{
+	$ignoreWhitespace = (bool)$_REQUEST['ignorews'];
+}
 
-	if (!$manualorder && is_numeric($rev1) && is_numeric($rev2) && $rev1 > $rev2) {
-		$temppath = $path1;
-		$path1 = $path2;
-		$path2 = $temppath;
+// Some page links put the revision with the path...
+if (strpos($path1, '@')) 
+{
+	list($path1, $rev1) = explode('@', $path1);
+}
+else if (strpos($path1, '@') === 0) 
+{
+	// Something went wrong. The path is missing.
+	$rev1 = substr($path1, 1);
+	$path1 = '/';
+}
 
-		$temprev = $rev1;
-		$rev1 = $rev2;
-		$rev2 = $temprev;
-	}
+if (strpos($path2, '@')) 
+{
+	list($path2, $rev2) = explode('@', $path2);
+}
+else if (strpos($path2, '@') === 0) 
+{
+	$rev2 = substr($path2, 1);
+	$path2 = '/';
+}
 
-	$vars['rev1url'] = $config->getURL($rep, $path1, 'dir').createRevAndPegString($rev1, $rev1);
-	$vars['rev2url'] = $config->getURL($rep, $path2, 'dir').createRevAndPegString($rev2, $rev2);
+$rev1 = checkRevision($rev1);
+$rev2 = checkRevision($rev2);
 
-	$url = $config->getURL($rep, '', 'comp');
-	$vars['reverselink'] = '<a href="'.$url.'compare%5B%5D='.urlencode($path2).'@'.$rev2.'&amp;compare%5B%5D='.urlencode($path1).'@'.$rev1.'&amp;manualorder=1'.($ignoreWhitespace ? '&amp;ignorews=1' : '').'">'.$lang['REVCOMP'].'</a>';
-	$toggleIgnoreWhitespace = '';
-	if ($ignoreWhitespace == $config->getIgnoreWhitespacesInDiff()) {
-		$toggleIgnoreWhitespace = '&amp;ignorews='.($ignoreWhitespace ? '0' : '1');
-	}
-	if (!$ignoreWhitespace) {
-		$vars['ignorewhitespacelink'] = '<a href="'.$url.'compare%5B%5D='.urlencode($path1).'@'.$rev1.'&amp;compare%5B%5D='.urlencode($path2).'@'.$rev2.($manualorder ? '&amp;manualorder=1' : '').$toggleIgnoreWhitespace.'">'.$lang['IGNOREWHITESPACE'].'</a>';
-	} else {
-		$vars['regardwhitespacelink'] = '<a href="'.$url.'compare%5B%5D='.urlencode($path1).'@'.$rev1.'&amp;compare%5B%5D='.urlencode($path2).'@'.$rev2.($manualorder ? '&amp;manualorder=1' : '').$toggleIgnoreWhitespace.'">'.$lang['REGARDWHITESPACE'].'</a>';
-	}
+// Choose a sensible comparison order unless told not to
 
-	if ($rev1 == 0) $rev1 = 'HEAD';
-	if ($rev2 == 0) $rev2 = 'HEAD';
+if (!$manualorder && is_numeric($rev1) && is_numeric($rev2) && $rev1 > $rev2) 
+{
+	$temppath = $path1;
+	$path1 = $path2;
+	$path2 = $temppath;
 
-	$vars['repname'] = escape($rep->getDisplayName());
-	$vars['action'] = $lang['PATHCOMPARISON'];
+	$temprev = $rev1;
+	$rev1 = $rev2;
+	$rev2 = $temprev;
+}
 
-	$hidden = '<input type="hidden" name="manualorder" value="1" />';
-	if ($config->multiViews) {
-		$hidden .= '<input type="hidden" name="op" value="comp"/>';
-	} else {
-		$hidden .= '<input type="hidden" name="repname" value="'.$repname.'" />';
-	}
-	$vars['compare_form'] = '<form method="get" action="'.$url.'" id="compare">'.$hidden;
-	$vars['compare_path1input'] = '<input type="text" size="40" name="compare[0]" value="'.escape($path1).'" />';
-	$vars['compare_path2input'] = '<input type="text" size="40" name="compare[1]" value="'.escape($path2).'" />';
-	$vars['compare_rev1input'] = '<input type="text" size="5" name="compare_rev[0]" value="'.$rev1.'" />';
-	$vars['compare_rev2input'] = '<input type="text" size="5" name="compare_rev[1]" value="'.$rev2.'" />';
-	$vars['compare_submit'] = '<input name="comparesubmit" type="submit" value="'.$lang['COMPAREPATHS'].'" />';
-	$vars['compare_endform'] = '</form>';
+$vars['rev1url'] = $config->getURL($rep, $path1, 'dir').createRevAndPegString($rev1, $rev1);
+$vars['rev2url'] = $config->getURL($rep, $path2, 'dir').createRevAndPegString($rev2, $rev2);
 
-	// safe paths are a hack for fixing XSS exploit
-	$vars['path1'] = escape($path1);
-	$vars['safepath1'] = escape($path1);
-	$vars['path2'] = escape($path2);
-	$vars['safepath2'] = escape($path2);
+$url = $config->getURL($rep, '', 'comp');
+$vars['reverselink'] = '<a href="'.$url.'compare%5B%5D='.urlencode($path2).'@'.$rev2.'&amp;compare%5B%5D='.urlencode($path1).'@'.$rev1.'&amp;manualorder=1'.($ignoreWhitespace ? '&amp;ignorews=1' : '').'">'.$lang['REVCOMP'].'</a>';
+$toggleIgnoreWhitespace = '';
 
-	$vars['rev1'] = $rev1;
-	$vars['rev2'] = $rev2;
+if ($ignoreWhitespace == $config->getIgnoreWhitespacesInDiff()) 
+{
+	$toggleIgnoreWhitespace = '&amp;ignorews='.($ignoreWhitespace ? '0' : '1');
+}
 
-	$history1 = $svnrep->getLog($path1, $rev1, 0, false, 1);
-	if (!$history1) {
+if (!$ignoreWhitespace) 
+{
+	$vars['ignorewhitespacelink'] = '<a href="'.$url.'compare%5B%5D='.urlencode($path1).'@'.$rev1.'&amp;compare%5B%5D='.urlencode($path2).'@'.$rev2.($manualorder ? '&amp;manualorder=1' : '').$toggleIgnoreWhitespace.'">'.$lang['IGNOREWHITESPACE'].'</a>';
+}
+else 
+{
+	$vars['regardwhitespacelink'] = '<a href="'.$url.'compare%5B%5D='.urlencode($path1).'@'.$rev1.'&amp;compare%5B%5D='.urlencode($path2).'@'.$rev2.($manualorder ? '&amp;manualorder=1' : '').$toggleIgnoreWhitespace.'">'.$lang['REGARDWHITESPACE'].'</a>';
+}
+
+if ($rev1 == 0) $rev1 = 'HEAD';
+if ($rev2 == 0) $rev2 = 'HEAD';
+
+$vars['repname'] = escape($rep->getDisplayName());
+$vars['action'] = $lang['PATHCOMPARISON'];
+
+$hidden = '<input type="hidden" name="manualorder" value="1" />';
+
+if ($config->multiViews) 
+{
+	$hidden .= '<input type="hidden" name="op" value="comp"/>';
+}
+else
+{
+	$hidden .= '<input type="hidden" name="repname" value="'.$repname.'" />';
+}
+
+$vars['compare_form'] = '<form method="get" action="'.$url.'" id="compare">'.$hidden;
+$vars['compare_path1input'] = '<input type="text" size="40" name="compare[0]" value="'.escape($path1).'" />';
+$vars['compare_path2input'] = '<input type="text" size="40" name="compare[1]" value="'.escape($path2).'" />';
+$vars['compare_rev1input'] = '<input type="text" size="5" name="compare_rev[0]" value="'.$rev1.'" />';
+$vars['compare_rev2input'] = '<input type="text" size="5" name="compare_rev[1]" value="'.$rev2.'" />';
+$vars['compare_submit'] = '<input name="comparesubmit" type="submit" value="'.$lang['COMPAREPATHS'].'" />';
+$vars['compare_endform'] = '</form>';
+
+// safe paths are a hack for fixing XSS exploit
+$vars['path1'] = escape($path1);
+$vars['safepath1'] = escape($path1);
+$vars['path2'] = escape($path2);
+$vars['safepath2'] = escape($path2);
+
+$vars['rev1'] = $rev1;
+$vars['rev2'] = $rev2;
+
+$history1 = $svnrep->getLog($path1, $rev1, 0, false, 1);
+if (!$history1) 
+{
+	http_response_code(404);
+	$vars['error'] = $lang['NOPATH'];
+}
+else
+{
+	$history2 = $svnrep->getLog($path2, $rev2, 0, false, 1);
+
+	if (!$history2) 
+	{
 		http_response_code(404);
 		$vars['error'] = $lang['NOPATH'];
-	} else {
-		$history2 = $svnrep->getLog($path2, $rev2, 0, false, 1);
-		if (!$history2) {
-			http_response_code(404);
-			$vars['error'] = $lang['NOPATH'];
-		}
 	}
+}
 
-	// Set variables used for the more recent of the two revisions
-	$history = ($rev1 >= $rev2 ? $history1 : $history2);
-	if ($history && $history->curEntry) {
-		$logEntry = $history->curEntry;
-		$vars['rev'] = $logEntry->rev;
-		$vars['peg'] = $peg;
-		$vars['date'] = $logEntry->date;
-		$vars['age'] = datetimeFormatDuration(time() - strtotime($logEntry->date));
-		$vars['author'] = $logEntry->author;
-		$vars['log'] = xml_entities($logEntry->msg);
-	} else {
-		$vars['warning'] = 'Problem with comparison.';
-	}
+// Set variables used for the more recent of the two revisions
+$history = ($rev1 >= $rev2 ? $history1 : $history2);
+if ($history && $history->curEntry) 
+{
+	$logEntry = $history->curEntry;
+	$vars['rev'] = $logEntry->rev;
+	$vars['peg'] = $peg;
+	$vars['date'] = $logEntry->date;
+	$vars['age'] = datetimeFormatDuration(time() - strtotime($logEntry->date));
+	$vars['author'] = $logEntry->author;
+	$vars['log'] = xml_entities($logEntry->msg);
+}
+else
+{
+	$vars['warning'] = 'Problem with comparison.';
+}
 
-	$noinput = empty($path1) || empty($path2);
+$noinput = empty($path1) || empty($path2);
 
-	// Generate the diff listing
+// Generate the diff listing
 
-	$relativePath1 = $path1;
-	$relativePath2 = $path2;
+$relativePath1 = $path1;
+$relativePath2 = $path2;
 
-	$svnpath1 = encodepath($svnrep->getSvnPath(str_replace(DIRECTORY_SEPARATOR, '/', $path1)));
-	$svnpath2 = encodepath($svnrep->getSvnPath(str_replace(DIRECTORY_SEPARATOR, '/', $path2)));
+$svnpath1 = encodepath($svnrep->getSvnPath(str_replace(DIRECTORY_SEPARATOR, '/', $path1)));
+$svnpath2 = encodepath($svnrep->getSvnPath(str_replace(DIRECTORY_SEPARATOR, '/', $path2)));
 
-	$debug = false;
+$debug = false;
 
-	if (!$noinput) {
-		$cmd = $config->getSvnCommand().$rep->svnCredentials().' diff '.($ignoreWhitespace ? '-x "-w --ignore-eol-style" ' : '').quote($svnpath1.'@'.$rev1).' '.quote($svnpath2.'@'.$rev2);
-	}
+if (!$noinput) 
+{
+	$cmd = $config->getSvnCommand().$rep->svnCredentials().' diff '.($ignoreWhitespace ? '-x "-w --ignore-eol-style" ' : '').quote($svnpath1.'@'.$rev1).' '.quote($svnpath2.'@'.$rev2);
+}
 
-	function clearVars() {
-		global $ignoreWhitespace, $listing, $index;
+function clearVars() 
+{
+	global $ignoreWhitespace, $listing, $index;
 
-		if ($ignoreWhitespace && $index > 1) {
-			$endBlock = false;
-			$previous = $index - 1;
-			if ($listing[$previous]['endpath']) $endBlock = 'newpath';
-			else if ($listing[$previous]['enddifflines']) $endBlock = 'difflines';
-			if ($endBlock !== false) {
-				// check if block ending at previous contains real diff data
-				$i = $previous;
-				$containsOnlyEqualDiff = true;
-				$addedLines = array();
-				$removedLines = array();
-				while ($i >= 0 && !$listing[$i - 1][$endBlock]) {
-					$diffclass = $listing[$i - 1]['diffclass'];
+	if ($ignoreWhitespace && $index > 1) 
+	{
+		$endBlock = false;
+		$previous = $index - 1;
+		if ($listing[$previous]['endpath']) $endBlock = 'newpath';
+		else if ($listing[$previous]['enddifflines']) $endBlock = 'difflines';
 
-					if ($diffclass !== 'diffadded' && $diffclass !== 'diffdeleted') {
-						if ($addedLines !== $removedLines) {
-							$containsOnlyEqualDiff = false;
-							break;
-						}
+		if ($endBlock !== false) 
+		{
+			// check if block ending at previous contains real diff data
+			$i = $previous;
+			$containsOnlyEqualDiff = true;
+			$addedLines = array();
+			$removedLines = array();
+			while ($i >= 0 && !$listing[$i - 1][$endBlock]) 
+			{
+				$diffclass = $listing[$i - 1]['diffclass'];
+
+				if ($diffclass !== 'diffadded' && $diffclass !== 'diffdeleted') 
+				{
+					if ($addedLines !== $removedLines) 
+					{
+						$containsOnlyEqualDiff = false;
+						break;
 					}
-					if (count($addedLines) > 0 && $addedLines === $removedLines) {
-						$addedLines = array();
-						$removedLines = array();
-					}
+				}
 
-					if ($diffclass === 'diff') {
-						$i--;
-						continue;
-					}
-					if ($diffclass === null) {
+				if (count($addedLines) > 0 && $addedLines === $removedLines) 
+				{
+					$addedLines = array();
+					$removedLines = array();
+				}
+
+				if ($diffclass === 'diff') 
+				{
+					$i--;
+					continue;
+				}
+
+				if ($diffclass === null) 
+				{
+					$containsOnlyEqualDiff = false;
+					break;;
+				}
+
+				if ($diffclass === 'diffdeleted') 
+				{
+					if (count($addedLines) <= count($removedLines)) 
+					{
 						$containsOnlyEqualDiff = false;
 						break;;
 					}
 
-					if ($diffclass === 'diffdeleted') {
-						if (count($addedLines) <= count($removedLines)) {
-							$containsOnlyEqualDiff = false;
-							break;;
-						}
-						array_unshift($removedLines, $listing[$i - 1]['line']);
-						$i--;
-						continue;
-					}
-
-					if ($diffclass === 'diffadded') {
-						if (count($removedLines) > 0) {
-							$containsOnlyEqualDiff = false;
-							break;;
-						}
-						array_unshift($addedLines, $listing[$i - 1]['line']);
-						$i--;
-						continue;
-					}
-
-					assert(false);
-				}
-				if ($containsOnlyEqualDiff) {
-					$containsOnlyEqualDiff = $addedLines === $removedLines;
+					array_unshift($removedLines, $listing[$i - 1]['line']);
+					$i--;
+					continue;
 				}
 
-				// remove blocks which only contain diffclass=diff and equal removes and adds
-				if ($containsOnlyEqualDiff) {
-					for ($j = $i - 1; $j < $index; $j++) {
-						unset($listing[$j]);
+				if ($diffclass === 'diffadded') 
+				{
+					if (count($removedLines) > 0) 
+					{
+						$containsOnlyEqualDiff = false;
+						break;;
 					}
-					$index = $i - 1;
+
+					array_unshift($addedLines, $listing[$i - 1]['line']);
+					$i--;
+					continue;
 				}
+
+				assert(false);
+			}
+
+			if ($containsOnlyEqualDiff) 
+			{
+				$containsOnlyEqualDiff = $addedLines === $removedLines;
+			}
+
+			// remove blocks which only contain diffclass=diff and equal removes and adds
+			if ($containsOnlyEqualDiff) 
+			{
+				for ($j = $i - 1; $j < $index; $j++) 
+				{
+					unset($listing[$j]);
+				}
+
+				$index = $i - 1;
 			}
 		}
-
-		$listvar = &$listing[$index];
-		$listvar['newpath'] = null;
-		$listvar['endpath'] = null;
-		$listvar['info'] = null;
-		$listvar['diffclass'] = null;
-		$listvar['difflines'] = null;
-		$listvar['enddifflines'] = null;
-		$listvar['properties'] = null;
 	}
 
-	$vars['success'] = false;
+	$listvar = &$listing[$index];
+	$listvar['newpath'] = null;
+	$listvar['endpath'] = null;
+	$listvar['info'] = null;
+	$listvar['diffclass'] = null;
+	$listvar['difflines'] = null;
+	$listvar['enddifflines'] = null;
+	$listvar['properties'] = null;
+}
 
-	if (!$noinput) {
-		// TODO: Report warning/error if comparison encounters any problems
-		if ($diff = popenCommand($cmd, 'r')) {
-			$listing = array();
-			$index = 0;
-			$indiff = false;
-			$indiffproper = false;
-			$getLine = true;
-			$node = null;
-			$bufferedLine = false;
+$vars['success'] = false;
 
-			$vars['success'] = true;
+if (!$noinput) 
+{
+	// TODO: Report warning/error if comparison encounters any problems
+	if ($diff = popenCommand($cmd, 'r')) 
+	{
+		$listing = array();
+		$index = 0;
+		$indiff = false;
+		$indiffproper = false;
+		$getLine = true;
+		$node = null;
+		$bufferedLine = false;
 
-			while (!feof($diff)) {
-				if ($getLine) {
-					if ($bufferedLine === false) {
-						$bufferedLine = rtrim(fgets($diff), "\r\n");
-					}
-					$newlineR = strpos($bufferedLine, "\r");
-					$newlineN = strpos($bufferedLine, "\n");
-					if ($newlineR === false && $newlineN === false) {
-						$line = $bufferedLine;
-						$bufferedLine = false;
-					} else {
-						$newline = ($newlineR < $newlineN ? $newlineR : $newlineN);
-						$line = substr($bufferedLine, 0, $newline);
-						$bufferedLine = substr($bufferedLine, $newline + 1);
-					}
+		$vars['success'] = true;
+
+		while (!feof($diff)) 
+		{
+			if ($getLine) 
+			{
+				if ($bufferedLine === false) 
+				{
+					$bufferedLine = rtrim(fgets($diff), "\r\n");
 				}
 
-				clearVars();
-				$getLine = true;
-				if ($debug) print 'Line = "'.$line.'"<br />';
-				if ($indiff) {
-					// If we're in a diff proper, just set up the line
-					if ($indiffproper) {
-						if (strlen($line) > 0 && ($line[0] == ' ' || $line[0] == '+' || $line[0] == '-')) {
-							$subline = escape(toOutputEncoding(substr($line, 1)));
-							$subline = rtrim($subline, "\n\r");
-							$subline = ($subline) ? expandTabs($subline) : '&nbsp;';
-							$listvar = &$listing[$index];
-							$listvar['line'] = $subline;
+				$newlineR = strpos($bufferedLine, "\r");
+				$newlineN = strpos($bufferedLine, "\n");
+				if ($newlineR === false && $newlineN === false) 
+				{
+					$line = $bufferedLine;
+					$bufferedLine = false;
+				}
+				else 
+				{
+					$newline = ($newlineR < $newlineN ? $newlineR : $newlineN);
+					$line = substr($bufferedLine, 0, $newline);
+					$bufferedLine = substr($bufferedLine, $newline + 1);
+				}
+			}
 
-							switch ($line[0]) {
-								case ' ':
-									$listvar['diffclass'] = 'diff';
-									if ($debug) print 'Including as diff: '.$subline.'<br />';
-									break;
+			clearVars();
+			$getLine = true;
+			if ($debug) print 'Line = "'.$line.'"<br />';
+			if ($indiff) 
+			{
+				// If we're in a diff proper, just set up the line
+				if ($indiffproper) 
+				{
+					if (strlen($line) > 0 && ($line[0] == ' ' || $line[0] == '+' || $line[0] == '-')) 
+					{
+						$subline = escape(toOutputEncoding(substr($line, 1)));
+						$subline = rtrim($subline, "\n\r");
+						$subline = ($subline) ? expandTabs($subline) : '&nbsp;';
+						$listvar = &$listing[$index];
+						$listvar['line'] = $subline;
 
-								case '+':
-									$listvar['diffclass'] = 'diffadded';
-									if ($debug) print 'Including as added: '.$subline.'<br />';
-									break;
+						switch ($line[0]) 
+						{
+							case ' ':
+								$listvar['diffclass'] = 'diff';
+								if ($debug) print 'Including as diff: '.$subline.'<br />';
+								break;
 
-								case '-':
-									$listvar['diffclass'] = 'diffdeleted';
-									if ($debug) print 'Including as removed: '.$subline.'<br />';
-									break;
-							}
-							$index++;
-						} else if ($line != '\ No newline at end of file') {
-							$indiffproper = false;
-							$listing[$index++]['enddifflines'] = true;
-							$getLine = false;
-							if ($debug) print 'Ending lines<br />';
+							case '+':
+								$listvar['diffclass'] = 'diffadded';
+								if ($debug) print 'Including as added: '.$subline.'<br />';
+								break;
+
+							case '-':
+								$listvar['diffclass'] = 'diffdeleted';
+								if ($debug) print 'Including as removed: '.$subline.'<br />';
+								break;
 						}
-						continue;
+						$index++;
+					} 
+					else if ($line != '\ No newline at end of file') 
+					{
+						$indiffproper = false;
+						$listing[$index++]['enddifflines'] = true;
+						$getLine = false;
+						if ($debug) print 'Ending lines<br />';
 					}
+					continue;
+				}
 
-					// Check for the start of a new diff area
-					if (!strncmp($line, '@@', 2)) {
-						$pos = strpos($line, '+');
-						$posline = substr($line, $pos);
-						$sline = 0;
-						$eline = 0;
-						sscanf($posline, '+%d,%d', $sline, $eline);
-						if ($debug) print 'sline = "'.$sline.'", eline = "'.$eline.'"<br />';
-						// Check that this isn't a file deletion
-						if ($sline == 0 && $eline == 0) {
+				// Check for the start of a new diff area
+				if (!strncmp($line, '@@', 2)) 
+				{
+					$pos = strpos($line, '+');
+					$posline = substr($line, $pos);
+					$sline = 0;
+					$eline = 0;
+					sscanf($posline, '+%d,%d', $sline, $eline);
+
+					if ($debug) print 'sline = "'.$sline.'", eline = "'.$eline.'"<br />';
+
+					// Check that this isn't a file deletion
+					if ($sline == 0 && $eline == 0) 
+					{
+						$line = fgets($diff);
+						if ($debug) print 'Ignoring: "'.$line.'"<br />';
+
+						while ($line[0] == ' ' || $line[0] == '+' || $line[0] == '-') 
+						{
 							$line = fgets($diff);
 							if ($debug) print 'Ignoring: "'.$line.'"<br />';
-							while ($line[0] == ' ' || $line[0] == '+' || $line[0] == '-') {
-								$line = fgets($diff);
-								if ($debug) print 'Ignoring: "'.$line.'"<br />';
-							}
-
-							$getLine = false;
-							if ($debug) print 'Unignoring previous - marking as deleted<br />';
-							$listing[$index++]['info'] = $lang['FILEDELETED'];
-
-						} else {
-							$listvar = &$listing[$index];
-							$listvar['difflines'] = $line;
-							$sline = 0;
-							$slen = 0;
-							$eline = 0;
-							$elen = 0;
-							sscanf($line, '@@ -%d,%d +%d,%d @@', $sline, $slen, $eline, $elen);
-							$listvar['rev1line'] = $sline;
-							$listvar['rev1len'] = $slen;
-							$listvar['rev2line'] = $eline;
-							$listvar['rev2len'] = $elen;
-
-							$indiffproper = true;
-
-							$index++;
 						}
 
-						continue;
+						$getLine = false;
+						if ($debug) print 'Unignoring previous - marking as deleted<br />';
+						$listing[$index++]['info'] = $lang['FILEDELETED'];
 
-					} else {
-						$indiff = false;
-						if ($debug) print 'Ending diff';
+					} 
+					else 
+					{
+						$listvar = &$listing[$index];
+						$listvar['difflines'] = $line;
+						$sline = 0;
+						$slen = 0;
+						$eline = 0;
+						$elen = 0;
+						sscanf($line, '@@ -%d,%d +%d,%d @@', $sline, $slen, $eline, $elen);
+						$listvar['rev1line'] = $sline;
+						$listvar['rev1len'] = $slen;
+						$listvar['rev2line'] = $eline;
+						$listvar['rev2len'] = $elen;
+
+						$indiffproper = true;
+
+						$index++;
 					}
+
+					continue;
+
+				} 
+				else 
+				{
+					$indiff = false;
+					if ($debug) print 'Ending diff';
+				}
+			}
+
+			// Check for a new node entry
+			if (strncmp(trim($line), 'Index: ', 7) == 0) 
+			{
+				// End the current node
+				if ($node) 
+				{
+					$listing[$index++]['endpath'] = true;
+					clearVars();
 				}
 
-				// Check for a new node entry
-				if (strncmp(trim($line), 'Index: ', 7) == 0) {
-					// End the current node
-					if ($node) {
+				$node = trim(toOutputEncoding($line));
+				$node = substr($node, 7);
+				if ($node == '' || $node[0] != '/') $node = '/'.$node;
+
+				if (substr($path2, -strlen($node)) === $node) 
+				{
+					$absnode = $path2;
+				}
+				else
+				{
+					$absnode = $path2;
+					if (substr($absnode, -1) == '/') $absnode = substr($absnode, 0, -1);
+					$absnode .= $node;
+				}
+
+				$listvar = &$listing[$index];
+				$listvar['newpath'] = escape($absnode);
+
+				$listvar['fileurl'] = $config->getURL($rep, escape($absnode), 'file').'rev='.$rev2;
+
+				if ($debug) echo 'Creating node '.$node.'<br />';
+
+				// Skip past the line of ='s
+				$line = fgets($diff);
+				if ($debug) print 'Skipping: '.$line.'<br />';
+
+				// Check for a file addition
+				$line = fgets($diff);
+				if ($debug) print 'Examining: '.$line.'<br />';
+				if (strpos($line, '(revision 0)')) 
+				{
+					$listvar['info'] = $lang['FILEADDED'];
+				}
+
+				if (strncmp(trim($line), 'Cannot display:', 15) == 0) 
+				{
+					$index++;
+					clearVars();
+					$listing[$index++]['info'] = escape(toOutputEncoding($line));
+					continue;
+				}
+
+				// Skip second file info
+				$line = fgets($diff);
+				if ($debug) print 'Skipping: '.$line.'<br />';
+
+				$indiff = true;
+				$index++;
+
+				continue;
+			}
+
+			if (strncmp(trim($line), 'Property changes on: ', 21) == 0) 
+			{
+				$propnode = trim($line);
+				$propnode = substr($propnode, 21);
+				if ($propnode == '' || $propnode[0] != '/') $propnode = '/'.$propnode;
+
+				if ($debug) print 'Properties on '.$propnode.' (cur node $ '.$node.')';
+				if ($propnode != $node) 
+				{
+					if ($node) 
+					{
 						$listing[$index++]['endpath'] = true;
 						clearVars();
 					}
 
-					$node = trim(toOutputEncoding($line));
-					$node = substr($node, 7);
-					if ($node == '' || $node[0] != '/') $node = '/'.$node;
+					$node = $propnode;
 
-					if (substr($path2, -strlen($node)) === $node) {
-						$absnode = $path2;
-					} else {
-						$absnode = $path2;
-						if (substr($absnode, -1) == '/') $absnode = substr($absnode, 0, -1);
-						$absnode .= $node;
+					$listing[$index++]['newpath'] = escape(toOutputEncoding($node));
+					clearVars();
+				}
+
+				$listing[$index++]['properties'] = true;
+				clearVars();
+				if ($debug) echo 'Creating node '.$node.'<br />';
+
+				// Skip the row of underscores
+				$line = fgets($diff);
+				if ($debug) print 'Skipping: '.$line.'<br />';
+
+				while ($line = trim(fgets($diff))) 
+				{
+					if (!strncmp($line, 'Index: ', 7)) 
+					{
+						break;
 					}
-
-					$listvar = &$listing[$index];
-					$listvar['newpath'] = escape($absnode);
-
-					$listvar['fileurl'] = $config->getURL($rep, escape($absnode), 'file').'rev='.$rev2;
-
-					if ($debug) echo 'Creating node '.$node.'<br />';
-
-					// Skip past the line of ='s
-					$line = fgets($diff);
-					if ($debug) print 'Skipping: '.$line.'<br />';
-
-					// Check for a file addition
-					$line = fgets($diff);
-					if ($debug) print 'Examining: '.$line.'<br />';
-					if (strpos($line, '(revision 0)')) {
-						$listvar['info'] = $lang['FILEADDED'];
-					}
-
-					if (strncmp(trim($line), 'Cannot display:', 15) == 0) {
-						$index++;
-						clearVars();
-						$listing[$index++]['info'] = escape(toOutputEncoding($line));
+					if (!strncmp($line, '##', 2) || $line == '\ No newline at end of file') 
+					{
 						continue;
 					}
-
-					// Skip second file info
-					$line = fgets($diff);
-					if ($debug) print 'Skipping: '.$line.'<br />';
-
-					$indiff = true;
-					$index++;
-
-					continue;
-				}
-
-				if (strncmp(trim($line), 'Property changes on: ', 21) == 0) {
-					$propnode = trim($line);
-					$propnode = substr($propnode, 21);
-					if ($propnode == '' || $propnode[0] != '/') $propnode = '/'.$propnode;
-
-					if ($debug) print 'Properties on '.$propnode.' (cur node $ '.$node.')';
-					if ($propnode != $node) {
-						if ($node) {
-							$listing[$index++]['endpath'] = true;
-							clearVars();
-						}
-
-						$node = $propnode;
-
-						$listing[$index++]['newpath'] = escape(toOutputEncoding($node));
-						clearVars();
-					}
-
-					$listing[$index++]['properties'] = true;
+					$listing[$index++]['info'] = escape(toOutputEncoding($line));
 					clearVars();
-					if ($debug) echo 'Creating node '.$node.'<br />';
-
-					// Skip the row of underscores
-					$line = fgets($diff);
-					if ($debug) print 'Skipping: '.$line.'<br />';
-
-					while ($line = trim(fgets($diff))) {
-						if (!strncmp($line, 'Index: ', 7)) {
-							break;
-						}
-						if (!strncmp($line, '##', 2) || $line == '\ No newline at end of file') {
-							continue;
-						}
-						$listing[$index++]['info'] = escape(toOutputEncoding($line));
-						clearVars();
-					}
-					$getLine = false;
-
-					continue;
 				}
+				$getLine = false;
 
-				// Check for error messages
-				if (strncmp(trim($line), 'svn: ', 5) == 0) {
-					$listing[$index++]['info'] = urldecode($line);
-					$vars['success'] = false;
-					continue;
-				}
-
-				$listing[$index++]['info'] = escape(toOutputEncoding($line));
-				
-				if (strlen($line) === 0) {
-					if (!$vars['warning']) {
-						$vars['warning'] = "No changes between revisions";
-					}
-				}
-				
+				continue;
 			}
 
-			if ($node) {
-				clearVars();
-				$listing[$index++]['endpath'] = true;
+			// Check for error messages
+			if (strncmp(trim($line), 'svn: ', 5) == 0) 
+			{
+				$listing[$index++]['info'] = urldecode($line);
+				$vars['success'] = false;
+				continue;
 			}
 
-			if ($debug) print_r($listing);
-
-			if (!$rep->hasUnrestrictedReadAccess($relativePath1) || !$rep->hasUnrestrictedReadAccess($relativePath2, false)) {
-				// check every item for access and remove it if read access is not allowed
-				$restricted = array();
-				$inrestricted = false;
-				foreach ($listing as $i => $item) {
-					if ($item['newpath'] !== null) {
-						$newpath = $item['newpath'];
-						$inrestricted = !$rep->hasReadAccess($newpath, false);
-					}
-					if ($inrestricted) {
-						$restricted[] = $i;
-					}
-					if ($item['endpath'] !== null) {
-						$inrestricted = false;
-					}
-				}
-				foreach ($restricted as $i) {
-					unset($listing[$i]);
-				}
-				if (count($restricted) && !count($listing)) {
-					$vars['error'] = $lang['NOACCESS'];
-					sendHeaderForbidden();
+			$listing[$index++]['info'] = escape(toOutputEncoding($line));
+			
+			if (strlen($line) === 0) 
+			{
+				if (!$vars['warning']) 
+				{
+					$vars['warning'] = "No changes between revisions";
 				}
 			}
-
-			pclose($diff);
+			
 		}
-	}
 
-} else {
-	http_response_code(404);
+		if ($node) 
+		{
+			clearVars();
+			$listing[$index++]['endpath'] = true;
+		}
+
+		if ($debug) print_r($listing);
+
+		if (!$rep->hasUnrestrictedReadAccess($relativePath1) || !$rep->hasUnrestrictedReadAccess($relativePath2, false)) 
+		{
+			// check every item for access and remove it if read access is not allowed
+			$restricted = array();
+			$inrestricted = false;
+			foreach ($listing as $i => $item) 
+			{
+				if ($item['newpath'] !== null) 
+				{
+					$newpath = $item['newpath'];
+					$inrestricted = !$rep->hasReadAccess($newpath, false);
+				}
+
+				if ($inrestricted) 
+				{
+					$restricted[] = $i;
+				}
+
+				if ($item['endpath'] !== null) 
+				{
+					$inrestricted = false;
+				}
+			}
+
+			foreach ($restricted as $i) 
+			{
+				unset($listing[$i]);
+			}
+
+			if (count($restricted) && !count($listing)) 
+			{
+				$vars['error'] = $lang['NOACCESS'];
+				sendHeaderForbidden();
+			}
+		}
+
+		pclose($diff);
+	}
 }
 
 renderTemplate('compare');

--- a/diff.php
+++ b/diff.php
@@ -38,157 +38,194 @@ if (array_key_exists('ignorews', $_REQUEST)) {
 }
 
 // Make sure that we have a repository
-if ($rep) {
-	$svnrep = new SVNRepository($rep);
+if (!$rep)
+{
+	renderTemplateNoRepo('diff');
+}
 
-	// If there's no revision info, go to the lastest revision for this path
-	$history = $svnrep->getLog($path, 'HEAD', 1, true, 2, ($path == '/') ? '' : $peg);
-	if (!$history) {
-		unset($vars['error']);
-		$history = $svnrep->getLog($path, '', '', true, 2, ($path == '/') ? '' : $peg);
-	}
-	$youngest = ($history && isset($history->entries[0])) ? $history->entries[0]->rev : false;
+$svnrep = new SVNRepository($rep);
 
-	if (empty($rev)) {
-		$rev = $youngest;
-	}
+// If there's no revision info, go to the lastest revision for this path
+$history = $svnrep->getLog($path, 'HEAD', 1, true, 2, ($path == '/') ? '' : $peg);
 
-	$history = $svnrep->getLog($path, $rev, 1, false, 2, $peg);
+if (!$history) 
+{
+	unset($vars['error']);
+	$history = $svnrep->getLog($path, '', '', true, 2, ($path == '/') ? '' : $peg);
+}
 
-	if ($path[0] != '/') {
-		$ppath = '/'.$path;
-	} else {
-		$ppath = $path;
-	}
+$youngest = ($history && isset($history->entries[0])) ? $history->entries[0]->rev : false;
 
-	$prevrev = @$history->entries[1]->rev;
+if (empty($rev)) 
+{
+	$rev = $youngest;
+}
 
-	$vars['path'] = escape($ppath);
-	$vars['rev1'] = $rev;
-	$vars['rev2'] = $prevrev;
-	$vars['prevrev'] = $prevrev;
+$history = $svnrep->getLog($path, $rev, 1, false, 2, $peg);
 
-	if (isset($history->entries[0])) {
-		$vars['log'] = xml_entities($history->entries[0]->msg);
-		$vars['date'] = $history->entries[0]->date;
-		$vars['age'] = datetimeFormatDuration(time() - strtotime($history->entries[0]->date));
-		$vars['author'] = $history->entries[0]->author;
-		$vars['rev'] = $vars['rev1'] = $history->entries[0]->rev;
-		$vars['peg'] = $peg;
-	}
+if ($path[0] != '/') 
+{
+	$ppath = '/'.$path;
+}
+else 
+{
+	$ppath = $path;
+}
 
-	createPathLinks($rep, $ppath, $passrev, $peg);
-	$passRevString = createRevAndPegString($rev, $peg);
+$prevrev = @$history->entries[1]->rev;
 
-	$passIgnoreWhitespace = '';
-	if ($ignoreWhitespace != $config->getIgnoreWhitespacesInDiff()) {
-		$passIgnoreWhitespace = '&amp;ignorews='.($ignoreWhitespace ? '1' : '0');
-	}
+$vars['path'] = escape($ppath);
+$vars['rev1'] = $rev;
+$vars['rev2'] = $prevrev;
+$vars['prevrev'] = $prevrev;
 
-	if ($rev != $youngest) {
-		$vars['goyoungesturl'] = $config->getURL($rep, $path, 'diff').createRevAndPegString('', $peg).$passIgnoreWhitespace;
-		$vars['goyoungestlink'] = '<a href="'.$vars['goyoungesturl'].'"'.($youngest ? ' title="'.$lang['REV'].' '.$youngest.'"' : '').'>'.$lang['GOYOUNGEST'].'</a>';
-	}
+if (isset($history->entries[0])) 
+{
+	$vars['log'] = xml_entities($history->entries[0]->msg);
+	$vars['date'] = $history->entries[0]->date;
+	$vars['age'] = datetimeFormatDuration(time() - strtotime($history->entries[0]->date));
+	$vars['author'] = $history->entries[0]->author;
+	$vars['rev'] = $vars['rev1'] = $history->entries[0]->rev;
+	$vars['peg'] = $peg;
+}
 
-	$revurl = $config->getURL($rep, $path, 'diff');
-	if ($rev < $youngest) {
-		$history2 = $svnrep->getLog($path, $rev, $youngest, true, 2, $peg ? $peg : 'HEAD');
-		if (isset($history2->entries[1])) {
-			$nextRev = $history2->entries[1]->rev;
-			if ($nextRev != $youngest) {
-				$vars['nextrev'] = $nextRev;
-				$vars['nextrevurl'] = $revurl.createRevAndPegString($nextRev, $peg).$passIgnoreWhitespace;
-			}
+createPathLinks($rep, $ppath, $passrev, $peg);
+$passRevString = createRevAndPegString($rev, $peg);
+
+$passIgnoreWhitespace = '';
+if ($ignoreWhitespace != $config->getIgnoreWhitespacesInDiff()) 
+{
+	$passIgnoreWhitespace = '&amp;ignorews='.($ignoreWhitespace ? '1' : '0');
+}
+
+if ($rev != $youngest) 
+{
+	$vars['goyoungesturl'] = $config->getURL($rep, $path, 'diff').createRevAndPegString('', $peg).$passIgnoreWhitespace;
+	$vars['goyoungestlink'] = '<a href="'.$vars['goyoungesturl'].'"'.($youngest ? ' title="'.$lang['REV'].' '.$youngest.'"' : '').'>'.$lang['GOYOUNGEST'].'</a>';
+}
+
+$revurl = $config->getURL($rep, $path, 'diff');
+
+if ($rev < $youngest) 
+{
+	$history2 = $svnrep->getLog($path, $rev, $youngest, true, 2, $peg ? $peg : 'HEAD');
+
+	if (isset($history2->entries[1])) 
+	{
+		$nextRev = $history2->entries[1]->rev;
+		if ($nextRev != $youngest) 
+		{
+			$vars['nextrev'] = $nextRev;
+			$vars['nextrevurl'] = $revurl.createRevAndPegString($nextRev, $peg).$passIgnoreWhitespace;
 		}
-		unset($vars['error']);
 	}
 
-	if (isset($history->entries[1])) {
-		$prevRev = $history->entries[1]->rev;
-		$prevPath = $history->entries[1]->path;
-		$vars['prevrev'] = $prevRev;
-		$vars['prevrevurl'] = $revurl.createRevAndPegString($prevRev, $peg).$passIgnoreWhitespace;
+	unset($vars['error']);
+}
+
+if (isset($history->entries[1])) 
+{
+	$prevRev = $history->entries[1]->rev;
+	$prevPath = $history->entries[1]->path;
+	$vars['prevrev'] = $prevRev;
+	$vars['prevrevurl'] = $revurl.createRevAndPegString($prevRev, $peg).$passIgnoreWhitespace;
+}
+
+$vars['revurl'] = $config->getURL($rep, $path, 'revision').$passRevString;
+$vars['revlink'] = '<a href="'.$vars['revurl'].'">'.$lang['LASTMOD'].'</a>';
+
+$vars['logurl'] = $config->getURL($rep, $path, 'log').$passRevString;
+$vars['loglink'] = '<a href="'.$vars['logurl'].'">'.$lang['VIEWLOG'].'</a>';
+
+$vars['filedetailurl'] = $config->getURL($rep, $path, 'file').$passRevString;
+$vars['filedetaillink'] = '<a href="'.$vars['filedetailurl'].'">'.$lang['FILEDETAIL'].'</a>';
+
+$vars['blameurl'] = $config->getURL($rep, $path, 'blame').$passRevString;
+$vars['blamelink'] = '<a href="'.$vars['blameurl'].'">'.$lang['BLAME'].'</a>';
+
+if ($rep->isRssEnabled()) 
+{
+	$vars['rssurl'] = $config->getURL($rep, $path, 'rss').createRevAndPegString('', $peg);
+	$vars['rsslink'] = '<a href="'.$vars['rssurl'].'">'.$lang['RSSFEED'].'</a>';
+}
+
+// Check for binary file type before diffing.
+$svnMimeType = $svnrep->getProperty($path, 'svn:mime-type', $rev);
+
+// If no previous revision exists, bail out before diffing
+if (!$rep->getIgnoreSvnMimeTypes() && preg_match('~application/*~', $svnMimeType)) 
+{
+	$vars['warning'] = 'Cannot display diff of binary file. (svn:mime-type = '.$svnMimeType.')';
+
+}
+else if (!$prevrev) 
+{
+	$vars['noprev'] = 1;
+}
+else
+{
+	$diff = $config->getURL($rep, $path, 'diff').$passRevString;
+
+	if ($all) 
+	{
+		$vars['showcompactlink'] = '<a href="'.$diff.$passIgnoreWhitespace.'">'.$lang['SHOWCOMPACT'].'</a>';
+	}
+	else 
+	{
+		$vars['showalllink'] = '<a href="'.$diff.$passIgnoreWhitespace.'&amp;all=1'.'">'.$lang['SHOWENTIREFILE'].'</a>';
 	}
 
-	$vars['revurl'] = $config->getURL($rep, $path, 'revision').$passRevString;
-	$vars['revlink'] = '<a href="'.$vars['revurl'].'">'.$lang['LASTMOD'].'</a>';
+	$passShowAll = ($all ? '&amp;all=1' : '');
+	$toggleIgnoreWhitespace = '';
 
-	$vars['logurl'] = $config->getURL($rep, $path, 'log').$passRevString;
-	$vars['loglink'] = '<a href="'.$vars['logurl'].'">'.$lang['VIEWLOG'].'</a>';
-
-	$vars['filedetailurl'] = $config->getURL($rep, $path, 'file').$passRevString;
-	$vars['filedetaillink'] = '<a href="'.$vars['filedetailurl'].'">'.$lang['FILEDETAIL'].'</a>';
-
-	$vars['blameurl'] = $config->getURL($rep, $path, 'blame').$passRevString;
-	$vars['blamelink'] = '<a href="'.$vars['blameurl'].'">'.$lang['BLAME'].'</a>';
-
-	if ($rep->isRssEnabled()) {
-		$vars['rssurl'] = $config->getURL($rep, $path, 'rss').createRevAndPegString('', $peg);
-		$vars['rsslink'] = '<a href="'.$vars['rssurl'].'">'.$lang['RSSFEED'].'</a>';
+	if ($ignoreWhitespace == $config->getIgnoreWhitespacesInDiff()) 
+	{
+		$toggleIgnoreWhitespace = '&amp;ignorews='.($ignoreWhitespace ? '0' : '1');
 	}
 
-	// Check for binary file type before diffing.
-	$svnMimeType = $svnrep->getProperty($path, 'svn:mime-type', $rev);
-
-	// If no previous revision exists, bail out before diffing
-	if (!$rep->getIgnoreSvnMimeTypes() && preg_match('~application/*~', $svnMimeType)) {
-		$vars['warning'] = 'Cannot display diff of binary file. (svn:mime-type = '.$svnMimeType.')';
-
-	} else if (!$prevrev) {
-		$vars['noprev'] = 1;
-
-	} else {
-		$diff = $config->getURL($rep, $path, 'diff').$passRevString;
-
-		if ($all) {
-			$vars['showcompactlink'] = '<a href="'.$diff.$passIgnoreWhitespace.'">'.$lang['SHOWCOMPACT'].'</a>';
-		} else {
-			$vars['showalllink'] = '<a href="'.$diff.$passIgnoreWhitespace.'&amp;all=1'.'">'.$lang['SHOWENTIREFILE'].'</a>';
-		}
-		$passShowAll = ($all ? '&amp;all=1' : '');
-		$toggleIgnoreWhitespace = '';
-		if ($ignoreWhitespace == $config->getIgnoreWhitespacesInDiff()) {
-			$toggleIgnoreWhitespace = '&amp;ignorews='.($ignoreWhitespace ? '0' : '1');
-		}
-		if ($ignoreWhitespace) {
-			$vars['regardwhitespacelink'] = '<a href="'.$diff.$passShowAll.$toggleIgnoreWhitespace.'">'.$lang['REGARDWHITESPACE'].'</a>';
-		} else {
-			$vars['ignorewhitespacelink'] = '<a href="'.$diff.$passShowAll.$toggleIgnoreWhitespace.'">'.$lang['IGNOREWHITESPACE'].'</a>';
-		}
-
-		// Get the contents of the two files
-		$newerFile = tempnamWithCheck($config->getTempDir(), '');
-		$newerFileHl = $newerFile.'highlight';
-		$normalNew = $svnrep->getFileContents($history->entries[0]->path, $newerFile, $history->entries[0]->rev, $peg, '', 'no');
-		$highlightedNew = $svnrep->getFileContents($history->entries[0]->path, $newerFileHl, $history->entries[0]->rev, $peg, '', 'line');
-
-		$olderFile = tempnamWithCheck($config->getTempDir(), '');
-		$olderFileHl = $olderFile.'highlight';
-		$normalOld = $svnrep->getFileContents($history->entries[0]->path, $olderFile, $history->entries[1]->rev, $peg, '', 'no');
-		$highlightedOld = $svnrep->getFileContents($history->entries[0]->path, $olderFileHl, $history->entries[1]->rev, $peg, '', 'line');
-		// TODO: Figured out why diffs across a move/rename are currently broken.
-
-		$highlighted = ($highlightedNew && $highlightedOld);
-		if ($highlighted) {
-			$listing = do_diff($all, $ignoreWhitespace, $highlighted, $newerFile, $olderFile, $newerFileHl, $olderFileHl);
-		} else {
-			$listing = do_diff($all, $ignoreWhitespace, $highlighted, $newerFile, $olderFile, null, null);
-		}
-
-		// Remove our temporary files
-		@unlink($newerFile);
-		@unlink($olderFile);
-		@unlink($newerFileHl);
-		@unlink($olderFileHl);
+	if ($ignoreWhitespace) 
+	{
+		$vars['regardwhitespacelink'] = '<a href="'.$diff.$passShowAll.$toggleIgnoreWhitespace.'">'.$lang['REGARDWHITESPACE'].'</a>';
+	}
+	else 
+	{
+		$vars['ignorewhitespacelink'] = '<a href="'.$diff.$passShowAll.$toggleIgnoreWhitespace.'">'.$lang['IGNOREWHITESPACE'].'</a>';
 	}
 
-	if (!$rep->hasReadAccess($path, false)) {
-		$vars['error'] = $lang['NOACCESS'];
-		sendHeaderForbidden();
+	// Get the contents of the two files
+	$newerFile = tempnamWithCheck($config->getTempDir(), '');
+	$newerFileHl = $newerFile.'highlight';
+	$normalNew = $svnrep->getFileContents($history->entries[0]->path, $newerFile, $history->entries[0]->rev, $peg, '', 'no');
+	$highlightedNew = $svnrep->getFileContents($history->entries[0]->path, $newerFileHl, $history->entries[0]->rev, $peg, '', 'line');
+
+	$olderFile = tempnamWithCheck($config->getTempDir(), '');
+	$olderFileHl = $olderFile.'highlight';
+	$normalOld = $svnrep->getFileContents($history->entries[0]->path, $olderFile, $history->entries[1]->rev, $peg, '', 'no');
+	$highlightedOld = $svnrep->getFileContents($history->entries[0]->path, $olderFileHl, $history->entries[1]->rev, $peg, '', 'line');
+	// TODO: Figured out why diffs across a move/rename are currently broken.
+
+	$highlighted = ($highlightedNew && $highlightedOld);
+
+	if ($highlighted) 
+	{
+		$listing = do_diff($all, $ignoreWhitespace, $highlighted, $newerFile, $olderFile, $newerFileHl, $olderFileHl);
+	}
+	else 
+	{
+		$listing = do_diff($all, $ignoreWhitespace, $highlighted, $newerFile, $olderFile, null, null);
 	}
 
-} else {
-	http_response_code(404);
+	// Remove our temporary files
+	@unlink($newerFile);
+	@unlink($olderFile);
+	@unlink($newerFileHl);
+	@unlink($olderFileHl);
+}
+
+if (!$rep->hasReadAccess($path, false)) 
+{
+	$vars['error'] = $lang['NOACCESS'];
+	sendHeaderForbidden();
 }
 
 renderTemplate('diff');

--- a/diff.php
+++ b/diff.php
@@ -40,7 +40,7 @@ if (array_key_exists('ignorews', $_REQUEST)) {
 // Make sure that we have a repository
 if (!$rep)
 {
-	renderTemplateNoRepo('diff');
+	renderTemplate404('diff',$lang['NOREP']);
 }
 
 $svnrep = new SVNRepository($rep);

--- a/diff.php
+++ b/diff.php
@@ -42,7 +42,7 @@ if (array_key_exists('ignorews', $_REQUEST))
 // Make sure that we have a repository
 if (!$rep)
 {
-	renderTemplate404('diff',$lang['NOREP']);
+	renderTemplate404('diff','NOREP');
 }
 
 $svnrep = new SVNRepository($rep);

--- a/diff.php
+++ b/diff.php
@@ -33,8 +33,10 @@ require_once 'include/diff_inc.php';
 $vars['action'] = $lang['DIFF'];
 $all = (@$_REQUEST['all'] == 1);
 $ignoreWhitespace = $config->getIgnoreWhitespacesInDiff();
-if (array_key_exists('ignorews', $_REQUEST)) {
-  $ignoreWhitespace = (bool)$_REQUEST['ignorews'];
+
+if (array_key_exists('ignorews', $_REQUEST)) 
+{
+	$ignoreWhitespace = (bool)$_REQUEST['ignorews'];
 }
 
 // Make sure that we have a repository

--- a/dl.php
+++ b/dl.php
@@ -81,206 +81,266 @@ if (!$rep->isDownloadAllowed($path)) {
 	exit;
 }
 
-if ($rep) {
-	$svnrep = new SVNRepository($rep);
+if (!$rep)
+{
+	http_response_code(404);
+	exit;
+}
 
-	// Fetch information about a revision (if unspecified, the latest) for this path
-	if (empty($rev)) {
-		$history = $svnrep->getLog($path, 'HEAD', '', true, 1, $peg);
-	} else if ($rev == $peg) {
-		$history = $svnrep->getLog($path, '', 1, true, 1, $peg);
-	} else {
-		$history = $svnrep->getLog($path, $rev, $rev - 1, true, 1, $peg);
-	}
-	$logEntry = ($history) ? $history->entries[0] : null;
+$svnrep = new SVNRepository($rep);
 
-	if (!$logEntry) {
-		http_response_code(404);
-		error_log('Unable to download resource at path: '.$path);
-		print 'Unable to download resource at path: '.xml_entities($path);
-		exit(0);
-	}
+// Fetch information about a revision (if unspecified, the latest) for this path
+if (empty($rev)) 
+{
+	$history = $svnrep->getLog($path, 'HEAD', '', true, 1, $peg);
+}
+else if ($rev == $peg) 
+{
+	$history = $svnrep->getLog($path, '', 1, true, 1, $peg);
+}
+else 
+{
+	$history = $svnrep->getLog($path, $rev, $rev - 1, true, 1, $peg);
+}
 
-	if (empty($rev)) {
-		$rev = $logEntry->rev;
-	}
+$logEntry = ($history) ? $history->entries[0] : null;
 
-	// Create a temporary filename to be used for a directory to archive a download.
-	// Here we have an unavoidable but highly unlikely to occur race condition.
-	$tempDir = tempnamWithCheck($config->getTempDir(), 'websvn');
+if (!$logEntry) 
+{
+	http_response_code(404);
+	error_log('Unable to download resource at path: '.$path);
+	print 'Unable to download resource at path: '.xml_entities($path);
+	exit(0);
+}
 
-	@unlink($tempDir);
-	mkdir($tempDir);
-	// Create the name of the directory being archived
-	$archiveName = $path;
-	$isDir = (substr($archiveName, -1) == '/');
-	if ($isDir) {
-		$archiveName = substr($archiveName, 0, -1);
-	}
-	$archiveName = basename($archiveName);
-	if ($archiveName == '') {
-		$archiveName = $rep->name;
-	}
-	$plainfilename = $archiveName;
-	$archiveName .= '.r'.$rev;
+if (empty($rev)) 
+{
+	$rev = $logEntry->rev;
+}
 
-	// Export the requested path from SVN repository to the temp directory
-	$svnExportResult = $svnrep->exportRepositoryPath($path, $tempDir.DIRECTORY_SEPARATOR.$archiveName, $rev, $peg);
-	if ($svnExportResult != 0) {
-		http_response_code(500);
-		error_log('svn export failed for: '.$archiveName);
-		print 'svn export failed for "'.xml_entities($archiveName).'".';
-		removeDirectory($tempDir);
-		exit(0);
-	}
+// Create a temporary filename to be used for a directory to archive a download.
+// Here we have an unavoidable but highly unlikely to occur race condition.
+$tempDir = tempnamWithCheck($config->getTempDir(), 'websvn');
 
-	// For security reasons, disallow direct downloads of filenames that
-	// are a symlink, since they may be a symlink to anywhere (/etc/passwd)
-	// Deciding whether the symlink is relative and legal within the
-	// repository would be nice but seems to error prone at this moment.
-	if ( is_link($tempDir.DIRECTORY_SEPARATOR.$archiveName) ) {
-		http_response_code(500);
-		error_log('to be downloaded file is symlink, aborting: '.$archiveName);
-		print 'Download of symlinks disallowed: "'.xml_entities($archiveName).'".';
-		removeDirectory($tempDir);
-		exit(0);
-	}
+@unlink($tempDir);
+mkdir($tempDir);
+// Create the name of the directory being archived
+$archiveName = $path;
+$isDir = (substr($archiveName, -1) == '/');
 
-	// Set timestamp of exported directory (and subdirectories) to timestamp of
-	// the revision so every archive of a given revision has the same timestamp.
-	$revDate = $logEntry->date;
-	$timestamp = mktime(substr($revDate, 11, 2), // hour
-											substr($revDate, 14, 2), // minute
-											substr($revDate, 17, 2), // second
-											substr($revDate, 5, 2), // month
-											substr($revDate, 8, 2), // day
-											substr($revDate, 0, 4)); // year
-	setDirectoryTimestamp($tempDir, $timestamp);
+if ($isDir) 
+{
+	$archiveName = substr($archiveName, 0, -1);
+}
 
-	// Change to temp directory so that only relative paths are stored in archive.
-	$oldcwd = getcwd();
-	chdir($tempDir);
+$archiveName = basename($archiveName);
 
-	if ($isDir) {
-		$downloadMode = $config->getDefaultDirectoryDlMode();
-	} else {
-		$downloadMode = $config->getDefaultFileDlMode();
-	}
+if ($archiveName == '') 
+{
+	$archiveName = $rep->name;
+}
 
-	// $_REQUEST parameter can override dlmode
-	if (!empty($_REQUEST['dlmode'])) {
-		$downloadMode = $_REQUEST['dlmode'];
-		if (substr($logEntry->path, -1) == '/') {
-			if (!in_array($downloadMode, $config->validDirectoryDlModes)) {
-				$downloadMode = $config->getDefaultDirectoryDlMode();
-			}
-		} else {
-			if (!in_array($downloadMode, $config->validFileDlModes)) {
-				$downloadMode = $config->getDefaultFileDlMode();
-			}
+$plainfilename = $archiveName;
+$archiveName .= '.r'.$rev;
+
+// Export the requested path from SVN repository to the temp directory
+$svnExportResult = $svnrep->exportRepositoryPath($path, $tempDir.DIRECTORY_SEPARATOR.$archiveName, $rev, $peg);
+
+if ($svnExportResult != 0) 
+{
+	http_response_code(500);
+	error_log('svn export failed for: '.$archiveName);
+	print 'svn export failed for "'.xml_entities($archiveName).'".';
+	removeDirectory($tempDir);
+	exit(0);
+}
+
+// For security reasons, disallow direct downloads of filenames that
+// are a symlink, since they may be a symlink to anywhere (/etc/passwd)
+// Deciding whether the symlink is relative and legal within the
+// repository would be nice but seems to error prone at this moment.
+if ( is_link($tempDir.DIRECTORY_SEPARATOR.$archiveName) ) 
+{
+	http_response_code(500);
+	error_log('to be downloaded file is symlink, aborting: '.$archiveName);
+	print 'Download of symlinks disallowed: "'.xml_entities($archiveName).'".';
+	removeDirectory($tempDir);
+	exit(0);
+}
+
+// Set timestamp of exported directory (and subdirectories) to timestamp of
+// the revision so every archive of a given revision has the same timestamp.
+$revDate = $logEntry->date;
+$timestamp = mktime(substr($revDate, 11, 2), // hour
+										substr($revDate, 14, 2), // minute
+										substr($revDate, 17, 2), // second
+										substr($revDate, 5, 2), // month
+										substr($revDate, 8, 2), // day
+										substr($revDate, 0, 4)); // year
+setDirectoryTimestamp($tempDir, $timestamp);
+
+// Change to temp directory so that only relative paths are stored in archive.
+$oldcwd = getcwd();
+chdir($tempDir);
+
+if ($isDir) 
+{
+	$downloadMode = $config->getDefaultDirectoryDlMode();
+} 
+else 
+{
+	$downloadMode = $config->getDefaultFileDlMode();
+}
+
+// $_REQUEST parameter can override dlmode
+if (!empty($_REQUEST['dlmode'])) 
+{
+	$downloadMode = $_REQUEST['dlmode'];
+
+	if (substr($logEntry->path, -1) == '/') 
+	{
+		if (!in_array($downloadMode, $config->validDirectoryDlModes)) 
+		{
+			$downloadMode = $config->getDefaultDirectoryDlMode();
 		}
 	}
+	else 
+	{
+		if (!in_array($downloadMode, $config->validFileDlModes)) 
+		{
+			$downloadMode = $config->getDefaultFileDlMode();
+		}
+	}
+}
 
-	$downloadArchive = $archiveName;
-	if ($downloadMode == 'plain') {
-		$downloadMimeType = 'application/octet-stream';
+$downloadArchive = $archiveName;
 
-	} else if ($downloadMode == 'zip') {
-		$downloadMimeType = 'application/zip';
-		$downloadArchive .= '.zip';
-		// Create zip file
-		$cmd = $config->zip.' --symlinks -r '.quote($downloadArchive).' '.quote($archiveName);
+if ($downloadMode == 'plain') 
+{
+	$downloadMimeType = 'application/octet-stream';
+
+}
+else if ($downloadMode == 'zip') 
+{
+	$downloadMimeType = 'application/zip';
+	$downloadArchive .= '.zip';
+	// Create zip file
+	$cmd = $config->zip.' --symlinks -r '.quote($downloadArchive).' '.quote($archiveName);
+	execCommand($cmd, $retcode);
+
+	if ($retcode != 0) 
+	{
+		error_log('Unable to call zip command: '.$cmd);
+		print 'Unable to call zip command. See webserver error log for details.';
+	}
+} 
+else 
+{
+	$downloadMimeType = 'application/gzip';
+	$downloadArchive .= '.tar.gz';
+	$tarArchive = $archiveName.'.tar';
+
+	// Create the tar file
+	$retcode = 0;
+
+	if (class_exists('Archive_Tar')) 
+	{
+		$tar = new Archive_Tar($tarArchive);
+		$created = $tar->create(array($archiveName));
+
+		if (!$created) 
+		{
+			$retcode = 1;
+			http_response_code(500);
+			print 'Unable to create tar archive.';
+		}
+	} 
+	else 
+	{
+		$cmd = $config->tar.' -cf '.quote($tarArchive).' '.quote($archiveName);
 		execCommand($cmd, $retcode);
-		if ($retcode != 0) {
-			error_log('Unable to call zip command: '.$cmd);
-			print 'Unable to call zip command. See webserver error log for details.';
+
+		if ($retcode != 0) 
+		{
+			http_response_code(500);
+			error_log('Unable to call tar command: '.$cmd);
+			print 'Unable to call tar command. See webserver error log for details.';
 		}
+	}
 
-	} else {
-		$downloadMimeType = 'application/gzip';
-		$downloadArchive .= '.tar.gz';
-		$tarArchive = $archiveName.'.tar';
+	if ($retcode != 0) 
+	{
+		chdir($oldcwd);
+		removeDirectory($tempDir);
+		exit(0);
+	}
 
-		// Create the tar file
-		$retcode = 0;
-		if (class_exists('Archive_Tar')) {
-			$tar = new Archive_Tar($tarArchive);
-			$created = $tar->create(array($archiveName));
-			if (!$created) {
-				$retcode = 1;
-				http_response_code(500);
-				print 'Unable to create tar archive.';
-			}
+	// Set timestamp of tar file to timestamp of revision
+	touch($tarArchive, $timestamp);
 
-		} else {
-			$cmd = $config->tar.' -cf '.quote($tarArchive).' '.quote($archiveName);
-			execCommand($cmd, $retcode);
-			if ($retcode != 0) {
-				http_response_code(500);
-				error_log('Unable to call tar command: '.$cmd);
-				print 'Unable to call tar command. See webserver error log for details.';
-			}
-		}
-		if ($retcode != 0) {
+	// GZIP it up
+	if (function_exists('gzopen')) 
+	{
+		$srcHandle = fopen($tarArchive, 'rb');
+		$dstHandle = gzopen($downloadArchive, 'wb');
+
+		if (!$srcHandle || !$dstHandle) 
+		{
+			http_response_code(500);
+			print 'Unable to open file for gz-compression.';
 			chdir($oldcwd);
 			removeDirectory($tempDir);
 			exit(0);
 		}
 
-		// Set timestamp of tar file to timestamp of revision
-		touch($tarArchive, $timestamp);
+		while (!feof($srcHandle)) 
+		{
+			gzwrite($dstHandle, fread($srcHandle, 1024 * 512));
+		}
 
-		// GZIP it up
-		if (function_exists('gzopen')) {
-			$srcHandle = fopen($tarArchive, 'rb');
-			$dstHandle = gzopen($downloadArchive, 'wb');
-			if (!$srcHandle || !$dstHandle) {
-				http_response_code(500);
-				print 'Unable to open file for gz-compression.';
-				chdir($oldcwd);
-				removeDirectory($tempDir);
-				exit(0);
-			}
-			while (!feof($srcHandle)) {
-				gzwrite($dstHandle, fread($srcHandle, 1024 * 512));
-			}
-			fclose($srcHandle);
-			gzclose($dstHandle);
+		fclose($srcHandle);
+		gzclose($dstHandle);
+	} 
+	else 
+	{
+		$cmd = $config->gzip.' '.quote($tarArchive);
+		$retcode = 0;
+		execCommand($cmd, $retcode);
 
-		} else {
-			$cmd = $config->gzip.' '.quote($tarArchive);
-			$retcode = 0;
-			execCommand($cmd, $retcode);
-			if ($retcode != 0) {
-				http_response_code(500);
-				error_log('Unable to call gzip command: '.$cmd);
-				print 'Unable to call gzip command. See webserver error log for details.';
-				chdir($oldcwd);
-				removeDirectory($tempDir);
-				exit(0);
-			}
+		if ($retcode != 0) 
+		{
+			http_response_code(500);
+			error_log('Unable to call gzip command: '.$cmd);
+			print 'Unable to call gzip command. See webserver error log for details.';
+			chdir($oldcwd);
+			removeDirectory($tempDir);
+			exit(0);
 		}
 	}
-
-	// Give the file to the browser
-	if (is_readable($downloadArchive)) {
-		if ($downloadMode == 'plain') {
-			$downloadFilename = $plainfilename;
-		} else {
-			$downloadFilename = $rep->name.'-'.$downloadArchive;
-		}
-		header('Content-Type: '.$downloadMimeType);
-		header('Content-Length: '.filesize($downloadArchive));
-		header('Content-Disposition: attachment; filename="'. $downloadFilename .'"');
-		readfile($downloadArchive);
-	} else {
-		http_response_code(404);
-		print 'Unable to open file: '.xml_entities($downloadArchive);
-	}
-
-	chdir($oldcwd);
-	removeDirectory($tempDir);
-
-} else {
-	http_response_code(404);
 }
+
+// Give the file to the browser
+if (is_readable($downloadArchive)) 
+{
+	if ($downloadMode == 'plain') 
+	{
+		$downloadFilename = $plainfilename;
+	}
+	else 
+	{
+		$downloadFilename = $rep->name.'-'.$downloadArchive;
+	}
+
+	header('Content-Type: '.$downloadMimeType);
+	header('Content-Length: '.filesize($downloadArchive));
+	header('Content-Disposition: attachment; filename="'. $downloadFilename .'"');
+	readfile($downloadArchive);
+}
+else 
+{
+	http_response_code(404);
+	print 'Unable to open file: '.xml_entities($downloadArchive);
+}
+
+chdir($oldcwd);
+removeDirectory($tempDir);

--- a/filedetails.php
+++ b/filedetails.php
@@ -30,7 +30,7 @@ require_once 'include/template.php';
 // Make sure that we have a repository
 if (!$rep)
 {
-	renderTemplateNoRepo('file');
+	renderTemplate404('file',$lang['NOREP']);
 }
 
 $svnrep = new SVNRepository($rep);
@@ -55,8 +55,7 @@ if (!$history)
 	$history = $svnrep->getLog($path, '', '', false, 2, ($path == '/') ? '' : $peg);
 	if (!$history) 
 	{
-		http_response_code(404);
-		$vars['error'] = $lang['NOPATH'];
+		renderTemplate404('file',$lang['NOPATH']);
 	}
 }
 
@@ -241,8 +240,7 @@ if (!$rep->hasReadAccess($path))
 }
 else if (!$svnrep->isFile($path, $rev, $peg)) 
 {
-	http_response_code(404);
-	$vars['error'] = $lang['NOPATH'];
+	renderTemplate404('file',$lang['NOPATH']);
 }
 
 // $listing is populated with file data when file.tmpl calls [websvn-getlisting]

--- a/filedetails.php
+++ b/filedetails.php
@@ -28,181 +28,222 @@ require_once 'include/utils.php';
 require_once 'include/template.php';
 
 // Make sure that we have a repository
-if ($rep) {
-	$svnrep = new SVNRepository($rep);
+if (!$rep)
+{
+	renderTemplateNoRepo('file');
+}
 
-	if ($path[0] != '/') {
-		$ppath = '/'.$path;
-	} else {
-		$ppath = $path;
-	}
+$svnrep = new SVNRepository($rep);
 
-	$useMime = false;
+if ($path[0] != '/') 
+{
+	$ppath = '/'.$path;
+} 
+else 
+{
+	$ppath = $path;
+}
 
-	// If there's no revision info, go to the lastest revision for this path
-	$history = $svnrep->getLog($path, 'HEAD', 1, false, 2, ($path == '/') ? '' : $peg);
-	if (!$history) {
-		unset($vars['error']);
-		$history = $svnrep->getLog($path, '', '', false, 2, ($path == '/') ? '' : $peg);
-		if (!$history) {
-			http_response_code(404);
-			$vars['error'] = $lang['NOPATH'];
-		}
-	}
-	$youngest = ($history && isset($history->entries[0])) ? $history->entries[0]->rev : false;
+$useMime = false;
 
-	if (empty($rev)) {
-		$rev = !$peg ? $youngest : min($peg, $youngest);
-	}
+// If there's no revision info, go to the lastest revision for this path
+$history = $svnrep->getLog($path, 'HEAD', 1, false, 2, ($path == '/') ? '' : $peg);
 
-	$extn = strtolower(strrchr($path, '.'));
-
-	// Check to see if the user has requested that this type be zipped and sent
-	// to the browser as an attachment
-
-	if ($history && isset($zipped) && in_array($extn, $zipped) && $rep->hasReadAccess($path, false)) {
-		$base = basename($path);
-		header('Content-Type: application/gzip');
-		header('Content-Disposition: attachment; filename='.urlencode($base).'.gz');
-
-		// Get the file contents and pipe into gzip. All this without creating
-		// a temporary file. Damn clever.
-		$svnrep->getFileContents($path, '', $rev, $peg, '| '.$config->gzip.' -n -f');
-		exit;
-	}
-
-	// Check to see if we should serve it with a particular content-type.
-	// The content-type could come from an svn:mime-type property on the
-	// file, or from the $contentType array in setup.php.
-
-	if (!$rep->getIgnoreSvnMimeTypes()) {
-		$svnMimeType = $svnrep->getProperty($path, 'svn:mime-type', $rev);
-	}
-
-	if (!$rep->getIgnoreWebSVNContentTypes()) {
-		$setupContentType = @$contentType[$extn];
-	}
-
-	// Use the documented priorities when establishing what content-type to use.
-	if (!empty($svnMimeType) && $svnMimeType != 'application/octet-stream') {
-		$mimeType = $svnMimeType;
-	} else if (!empty($setupContentType)) {
-		$mimeType = $setupContentType;
-	} else if (!empty($svnMimeType)) {
-		$mimeType = $svnMimeType; // Use SVN's default of 'application/octet-stream'
-	} else {
-		$mimeType = '';
-	}
-
-	$useMime = ($mimeType) ? @$_REQUEST['usemime'] : false;
-	if ($history && !empty($mimeType) && !$useMime) {
-		$useMime = $mimeType; // Save MIME type for later before possibly clobbering
-		// If a MIME type exists but is set to be ignored, set it to an empty string.
-		foreach ($config->inlineMimeTypes as $inlineType) {
-			if (preg_match('|'.$inlineType.'|', $mimeType)) {
-				$mimeType = '';
-				break;
-			}
-		}
-	}
-
-	// If a MIME type is associated with the file, deliver with Content-Type header.
-	if ($history && !empty($mimeType) && $rep->hasReadAccess($path, false)) {
-		$base = basename($path);
-		header('Content-Type: '.$mimeType);
-		//header('Content-Length: '.$size);
-		header("Content-Disposition: inline; filename*=UTF-8''" . rawurlencode($base));
-		$svnrep->getFileContents($path, '', $rev, $peg);
-		exit;
-	}
-
-	// Display the file inline using WebSVN.
-
-	$vars['action'] = '';
-	$vars['path'] = escape($ppath);
-
-	if (isset($history->entries[0])) {
-		$vars['log'] = xml_entities($history->entries[0]->msg);
-		$vars['date'] = $history->entries[0]->date;
-		$vars['age'] = datetimeFormatDuration(time() - strtotime($history->entries[0]->date));
-		$vars['author'] = $history->entries[0]->author;
-	}
-	createPathLinks($rep, $ppath, !$passrev && $peg ? $rev : $passrev, $peg);
-	$passRevString = createRevAndPegString($rev, $peg);
-
-	if ($rev != $youngest) {
-		$vars['goyoungesturl'] = $config->getURL($rep, $path, 'file').createRevAndPegString($youngest, $peg);
-		$vars['goyoungestlink'] = '<a href="'.$vars['goyoungesturl'].'"'.($youngest ? ' title="'.$lang['REV'].' '.$youngest.'"' : '').'>'.$lang['GOYOUNGEST'].'</a>';
-	}
-
-	$revurl = $config->getURL($rep, $path, 'file');
-	if ($rev < $youngest) {
-		$history2 = $svnrep->getLog($path, $rev, $youngest, true, 2, $peg ? $peg : 'HEAD');
-		if (isset($history2->entries[1])) {
-			$nextRev = $history2->entries[1]->rev;
-			if ($nextRev != $youngest) {
-				$vars['nextrev'] = $nextRev;
-				$vars['nextrevurl'] = $revurl.createRevAndPegString($nextRev, $peg);
-			}
-		}
-		unset($vars['error']);
-	}
-
-	$history3 = $svnrep->getLog($path, $rev, 1, true, 2, $peg ? $peg : 'HEAD');
-	if (isset($history3->entries[1])) {
-		$prevRev = $history3->entries[1]->rev;
-		$prevPath = $history3->entries[1]->path;
-		$vars['prevrev'] = $prevRev;
-		$vars['prevrevurl'] = $revurl.createRevAndPegString($prevRev, $peg);
-	}
+if (!$history) 
+{
 	unset($vars['error']);
-
-	$vars['revurl'] = $config->getURL($rep, $path, 'revision').$passRevString;
-	$vars['revlink'] = '<a href="'.$vars['revurl'].'">'.$lang['LASTMOD'].'</a>';
-
-	$vars['logurl'] = $config->getURL($rep, $path, 'log').$passRevString;
-	$vars['loglink'] = '<a href="'.$vars['logurl'].'">'.$lang['VIEWLOG'].'</a>';
-
-	$vars['blameurl'] = $config->getURL($rep, $path, 'blame').$passRevString;
-	$vars['blamelink'] = '<a href="'.$vars['blameurl'].'">'.$lang['BLAME'].'</a>';
-
-	if ($history == null || count($history->entries) > 1) {
-		$vars['diffurl'] = $config->getURL($rep, $path, 'diff').$passRevString;
-		$vars['difflink'] = '<a href="'.$vars['diffurl'].'">'.$lang['DIFFPREV'].'</a>';
-	}
-
-	if ($rep->isDownloadAllowed($path)) {
-		$vars['downloadlurl'] = $config->getURL($rep, $path, 'dl').$passRevString;
-		$vars['downloadlink'] = '<a href="'.$vars['downloadlurl'].'">'.$lang['DOWNLOAD'].'</a>';
-	}
-
-	if ($rep->isRssEnabled()) {
-		$vars['rssurl'] = $config->getURL($rep, $path, 'rss').createRevAndPegString('', $peg);
-		$vars['rsslink'] = '<a href="'.$vars['rssurl'].'">'.$lang['RSSFEED'].'</a>';
-	}
-
-	$mimeType = $useMime; // Restore preserved value to use for 'mimelink' variable.
-	// If there was a MIME type, create a link to display file with that type.
-	if ($mimeType && !isset($vars['warning'])) {
-		$vars['mimeurl'] = $config->getURL($rep, $path, 'file').'usemime=1&amp;'.$passRevString;
-		$vars['mimelink'] = '<a href="'.$vars['mimeurl'].'">'.$lang['VIEWAS'].' "'.$mimeType.'"</a>';
-	}
-
-	$vars['rev'] = escape($rev);
-	$vars['peg'] = $peg;
-
-	if (!$rep->hasReadAccess($path)) {
-		$vars['error'] = $lang['NOACCESS'];
-		sendHeaderForbidden();
-	} else if (!$svnrep->isFile($path, $rev, $peg)) {
+	$history = $svnrep->getLog($path, '', '', false, 2, ($path == '/') ? '' : $peg);
+	if (!$history) 
+	{
 		http_response_code(404);
 		$vars['error'] = $lang['NOPATH'];
 	}
+}
 
-} else {
+$youngest = ($history && isset($history->entries[0])) ? $history->entries[0]->rev : false;
+
+if (empty($rev)) 
+{
+	$rev = !$peg ? $youngest : min($peg, $youngest);
+}
+
+$extn = strtolower(strrchr($path, '.'));
+
+// Check to see if the user has requested that this type be zipped and sent
+// to the browser as an attachment
+
+if ($history && isset($zipped) && in_array($extn, $zipped) && $rep->hasReadAccess($path, false)) 
+{
+	$base = basename($path);
+	header('Content-Type: application/gzip');
+	header('Content-Disposition: attachment; filename='.urlencode($base).'.gz');
+
+	// Get the file contents and pipe into gzip. All this without creating
+	// a temporary file. Damn clever.
+	$svnrep->getFileContents($path, '', $rev, $peg, '| '.$config->gzip.' -n -f');
+	exit;
+}
+
+// Check to see if we should serve it with a particular content-type.
+// The content-type could come from an svn:mime-type property on the
+// file, or from the $contentType array in setup.php.
+
+if (!$rep->getIgnoreSvnMimeTypes()) 
+{
+	$svnMimeType = $svnrep->getProperty($path, 'svn:mime-type', $rev);
+}
+
+if (!$rep->getIgnoreWebSVNContentTypes()) 
+{
+	$setupContentType = @$contentType[$extn];
+}
+
+// Use the documented priorities when establishing what content-type to use.
+if (!empty($svnMimeType) && $svnMimeType != 'application/octet-stream') 
+{
+	$mimeType = $svnMimeType;
+}
+else if (!empty($setupContentType)) 
+{
+	$mimeType = $setupContentType;
+}
+else if (!empty($svnMimeType)) 
+{
+	$mimeType = $svnMimeType; // Use SVN's default of 'application/octet-stream'
+}
+else 
+{
+	$mimeType = '';
+}
+
+$useMime = ($mimeType) ? @$_REQUEST['usemime'] : false;
+
+if ($history && !empty($mimeType) && !$useMime) 
+{
+	$useMime = $mimeType; // Save MIME type for later before possibly clobbering
+	// If a MIME type exists but is set to be ignored, set it to an empty string.
+	foreach ($config->inlineMimeTypes as $inlineType) 
+	{
+		if (preg_match('|'.$inlineType.'|', $mimeType)) 
+		{
+			$mimeType = '';
+			break;
+		}
+	}
+}
+
+// If a MIME type is associated with the file, deliver with Content-Type header.
+if ($history && !empty($mimeType) && $rep->hasReadAccess($path, false)) 
+{
+	$base = basename($path);
+	header('Content-Type: '.$mimeType);
+	//header('Content-Length: '.$size);
+	header("Content-Disposition: inline; filename*=UTF-8''" . rawurlencode($base));
+	$svnrep->getFileContents($path, '', $rev, $peg);
+	exit;
+}
+
+// Display the file inline using WebSVN.
+
+$vars['action'] = '';
+$vars['path'] = escape($ppath);
+
+if (isset($history->entries[0])) 
+{
+	$vars['log'] = xml_entities($history->entries[0]->msg);
+	$vars['date'] = $history->entries[0]->date;
+	$vars['age'] = datetimeFormatDuration(time() - strtotime($history->entries[0]->date));
+	$vars['author'] = $history->entries[0]->author;
+}
+
+createPathLinks($rep, $ppath, !$passrev && $peg ? $rev : $passrev, $peg);
+$passRevString = createRevAndPegString($rev, $peg);
+
+if ($rev != $youngest) 
+{
+	$vars['goyoungesturl'] = $config->getURL($rep, $path, 'file').createRevAndPegString($youngest, $peg);
+	$vars['goyoungestlink'] = '<a href="'.$vars['goyoungesturl'].'"'.($youngest ? ' title="'.$lang['REV'].' '.$youngest.'"' : '').'>'.$lang['GOYOUNGEST'].'</a>';
+}
+
+$revurl = $config->getURL($rep, $path, 'file');
+
+if ($rev < $youngest) 
+{
+	$history2 = $svnrep->getLog($path, $rev, $youngest, true, 2, $peg ? $peg : 'HEAD');
+
+	if (isset($history2->entries[1])) 
+	{
+		$nextRev = $history2->entries[1]->rev;
+		if ($nextRev != $youngest) 
+		{
+			$vars['nextrev'] = $nextRev;
+			$vars['nextrevurl'] = $revurl.createRevAndPegString($nextRev, $peg);
+		}
+	}
+
+	unset($vars['error']);
+}
+
+$history3 = $svnrep->getLog($path, $rev, 1, true, 2, $peg ? $peg : 'HEAD');
+
+if (isset($history3->entries[1])) 
+{
+	$prevRev = $history3->entries[1]->rev;
+	$prevPath = $history3->entries[1]->path;
+	$vars['prevrev'] = $prevRev;
+	$vars['prevrevurl'] = $revurl.createRevAndPegString($prevRev, $peg);
+}
+
+unset($vars['error']);
+
+$vars['revurl'] = $config->getURL($rep, $path, 'revision').$passRevString;
+$vars['revlink'] = '<a href="'.$vars['revurl'].'">'.$lang['LASTMOD'].'</a>';
+
+$vars['logurl'] = $config->getURL($rep, $path, 'log').$passRevString;
+$vars['loglink'] = '<a href="'.$vars['logurl'].'">'.$lang['VIEWLOG'].'</a>';
+
+$vars['blameurl'] = $config->getURL($rep, $path, 'blame').$passRevString;
+$vars['blamelink'] = '<a href="'.$vars['blameurl'].'">'.$lang['BLAME'].'</a>';
+
+if ($history == null || count($history->entries) > 1) 
+{
+	$vars['diffurl'] = $config->getURL($rep, $path, 'diff').$passRevString;
+	$vars['difflink'] = '<a href="'.$vars['diffurl'].'">'.$lang['DIFFPREV'].'</a>';
+}
+
+if ($rep->isDownloadAllowed($path)) 
+{
+	$vars['downloadlurl'] = $config->getURL($rep, $path, 'dl').$passRevString;
+	$vars['downloadlink'] = '<a href="'.$vars['downloadlurl'].'">'.$lang['DOWNLOAD'].'</a>';
+}
+
+if ($rep->isRssEnabled()) 
+{
+	$vars['rssurl'] = $config->getURL($rep, $path, 'rss').createRevAndPegString('', $peg);
+	$vars['rsslink'] = '<a href="'.$vars['rssurl'].'">'.$lang['RSSFEED'].'</a>';
+}
+
+$mimeType = $useMime; // Restore preserved value to use for 'mimelink' variable.
+// If there was a MIME type, create a link to display file with that type.
+if ($mimeType && !isset($vars['warning'])) 
+{
+	$vars['mimeurl'] = $config->getURL($rep, $path, 'file').'usemime=1&amp;'.$passRevString;
+	$vars['mimelink'] = '<a href="'.$vars['mimeurl'].'">'.$lang['VIEWAS'].' "'.$mimeType.'"</a>';
+}
+
+$vars['rev'] = escape($rev);
+$vars['peg'] = $peg;
+
+if (!$rep->hasReadAccess($path)) 
+{
+	$vars['error'] = $lang['NOACCESS'];
+	sendHeaderForbidden();
+}
+else if (!$svnrep->isFile($path, $rev, $peg)) 
+{
 	http_response_code(404);
+	$vars['error'] = $lang['NOPATH'];
 }
 
 // $listing is populated with file data when file.tmpl calls [websvn-getlisting]
-
 renderTemplate('file');

--- a/filedetails.php
+++ b/filedetails.php
@@ -30,7 +30,7 @@ require_once 'include/template.php';
 // Make sure that we have a repository
 if (!$rep)
 {
-	renderTemplate404('file',$lang['NOREP']);
+	renderTemplate404('file','NOREP');
 }
 
 $svnrep = new SVNRepository($rep);
@@ -55,7 +55,7 @@ if (!$history)
 	$history = $svnrep->getLog($path, '', '', false, 2, ($path == '/') ? '' : $peg);
 	if (!$history) 
 	{
-		renderTemplate404('file',$lang['NOPATH']);
+		renderTemplate404('file','NOPATH');
 	}
 }
 
@@ -240,7 +240,7 @@ if (!$rep->hasReadAccess($path))
 }
 else if (!$svnrep->isFile($path, $rev, $peg)) 
 {
-	renderTemplate404('file',$lang['NOPATH']);
+	renderTemplate404('file','NOPATH');
 }
 
 // $listing is populated with file data when file.tmpl calls [websvn-getlisting]

--- a/include/template.php
+++ b/include/template.php
@@ -296,7 +296,7 @@ function renderTemplate404($view, $errorDetail="")
 {
 	global $vars, $lang;
 	http_response_code(404);
-	$vars['error'] = "WebSVN 404 ".$errorDetail;
+	$vars['error'] = "WebSVN 404 ".$lang[$errorDetail];
 	renderTemplate($view);
 	exit(0);
 }

--- a/include/template.php
+++ b/include/template.php
@@ -294,7 +294,9 @@ function executePlainPhpTemplate($vars) {
 
 function renderTemplateNoRepo($view)
 {
+	global $vars;
 	http_response_code(404);
+	$vars['error'] = "WebSVN 404 Error Not Found";
 	renderTemplate($view);
 	exit(0);
 }

--- a/include/template.php
+++ b/include/template.php
@@ -290,13 +290,13 @@ function executePlainPhpTemplate($vars) {
 	require_once $vars['templateentrypoint'];
 }
 
-// {{{ renderTemplateNoRepo
+// {{{ renderTemplate404
 
-function renderTemplateNoRepo($view)
+function renderTemplate404($view, $errorDetail="")
 {
-	global $vars;
+	global $vars, $lang;
 	http_response_code(404);
-	$vars['error'] = "WebSVN 404 Error Not Found";
+	$vars['error'] = "WebSVN 404 ".$errorDetail;
 	renderTemplate($view);
 	exit(0);
 }

--- a/listing.php
+++ b/listing.php
@@ -404,8 +404,7 @@ if (!$history)
 
 	if (!$history) 
 	{
-		http_response_code(404);
-		$vars['error'] = $lang['NOPATH'];
+		renderTemplate404('directory',$lang['NOPATH']);
 	}
 }
 

--- a/listing.php
+++ b/listing.php
@@ -458,7 +458,7 @@ function showTreeDir($svnrep, $path, $rev, $peg, $listing)
 // Make sure that we have a repository
 if (!$rep)
 {
-	renderTemplate404('directory',$lang['NOREP']);
+	renderTemplate404('directory','NOREP');
 }
 
 $svnrep = new SVNRepository($rep);
@@ -483,7 +483,7 @@ if (!$history)
 
 	if (!$history) 
 	{
-		renderTemplate404('directory',$lang['NOPATH']);
+		renderTemplate404('directory','NOPATH');
 	}
 }
 

--- a/listing.php
+++ b/listing.php
@@ -28,40 +28,51 @@ require_once 'include/utils.php';
 require_once 'include/template.php';
 require_once 'include/bugtraq.php';
 
-function removeURLSeparator($url) {
+function removeURLSeparator($url) 
+{
 	return preg_replace('#(\?|&(amp;)?)$#', '', $url);
 }
 
-function urlForPath($fullpath, $passRevString) {
+function urlForPath($fullpath, $passRevString) 
+{
 	global $config, $rep;
 
 	$isDir = $fullpath[strlen($fullpath) - 1] == '/';
-	if ($isDir) {
-		if ($config->treeView) {
+	if ($isDir) 
+	{
+		if ($config->treeView) 
+		{
 			$url = $config->getURL($rep, $fullpath, 'dir').$passRevString;
 			$id = anchorForPath($fullpath);
 			$url .= '#'.$id.'" id="'.$id;
-		} else {
+		} 
+		else 
+		{
 			$url = $config->getURL($rep, $fullpath, 'dir').$passRevString;
 		}
-	} else {
+	} 
+	else 
+	{
 		$url = $config->getURL($rep, $fullpath, 'file').$passRevString;
 	}
 	return removeURLSeparator($url);
 }
 
-function showDirFiles($svnrep, $subs, $level, $limit, $rev, $peg, $listing, $index, $treeview = true) {
+function showDirFiles($svnrep, $subs, $level, $limit, $rev, $peg, $listing, $index, $treeview = true) 
+{
 	global $config, $lang, $rep, $passrev, $peg, $passRevString;
 
 	$path = '';
 
-	if (!$treeview) {
+	if (!$treeview) 
+	{
 		$level = $limit;
 	}
 
 	// TODO: Fix node links to use the path and number of peg revision (if exists)
 	// This applies to file detail, log, and RSS -- leave the download link as-is
-	for ($n = 0; $n <= $level; $n++) {
+	for ($n = 0; $n <= $level; $n++) 
+	{
 		$path .= $subs[$n].'/';
 	}
 
@@ -71,11 +82,14 @@ function showDirFiles($svnrep, $subs, $level, $limit, $rev, $peg, $listing, $ind
 	$accessToThisDir = $rep->hasReadAccess($path, false);
 
 	// If using flat view and not at the root, create a '..' entry at the top.
-	if (!$treeview && count($subs) > 2) {
+	if (!$treeview && count($subs) > 2) 
+	{
 		$parentPath = $subs;
 		unset($parentPath[count($parentPath) - 2]);
 		$parentPath = implode('/', $parentPath);
-		if ($rep->hasReadAccess($parentPath, false)) {
+
+		if ($rep->hasReadAccess($parentPath, false)) 
+		{
 			$listvar = &$listing[$index];
 			$listvar['rowparity'] = $index % 2;
 			$listvar['path'] = $parentPath;
@@ -96,11 +110,15 @@ function showDirFiles($svnrep, $subs, $level, $limit, $rev, $peg, $listing, $ind
 
 	$openDir = false;
 	$logList = $svnrep->getList($path, $rev, $peg);
-	if ($logList) {
+
+	if ($logList) 
+	{
 		$downloadRevAndPeg = createRevAndPegString($rev, $peg ? $peg : $rev);
-		foreach ($logList->entries as $entry) {
+		foreach ($logList->entries as $entry) 
+		{
 			$isDir = $entry->isdir;
-			if (!$isDir && $level != $limit) {
+			if (!$isDir && $level != $limit) 
+			{
 				continue; // Skip any files outside the current directory
 			}
 			$file = $entry->file;
@@ -110,39 +128,56 @@ function showDirFiles($svnrep, $subs, $level, $limit, $rev, $peg, $listing, $ind
 			$access = ($isDir)	? $rep->hasReadAccess($path.$file, false)
 								: $accessToThisDir;
 
-			if ($access) {
+			if ($access) 
+			{
 				$listvar = &$listing[$index];
 				$listvar['rowparity'] = $index % 2;
 
-				if ($isDir) {
+				if ($isDir) 
+				{
 					$listvar['filetype'] = ($openDir) ? 'diropen' : 'dir';
 					$openDir = isset($subs[$level + 1]) && (!strcmp($subs[$level + 1].'/', $file) || !strcmp($subs[$level + 1], $file));
-				} else {
+				} 
+				else 
+				{
 					$listvar['filetype'] = strtolower(strrchr($file, '.'));
 					$openDir = false;
 				}
+
 				$listvar['isDir'] = $isDir;
 				$listvar['openDir'] = $openDir;
 				$listvar['level'] = ($treeview) ? $level : 0;
 				$listvar['node'] = 0; // t-node
 				$listvar['path'] = $path.$file;
 				$listvar['filename'] = escape($file);
-				if ($isDir) {
+
+				if ($isDir) 
+				{
 					$listvar['fileurl'] = urlForPath($path.$file, $passRevString);
-				} else {
+				} 
+				else 
+				{
 					$listvar['fileurl'] = urlForPath($path.$file, createDifferentRevAndPegString($passrev, $peg));
 				}
+
 				$listvar['filelink'] = '<a href="'.$listvar['fileurl'].'">'.$listvar['filename'].'</a>';
-				if ($isDir) {
+
+				if ($isDir) 
+				{
 					$listvar['logurl'] = $config->getURL($rep, $path.$file, 'log').$isDirString.$passRevString;
-				} else {
+				}
+				else 
+				{
 					$listvar['logurl'] = $config->getURL($rep, $path.$file, 'log').$isDirString.createDifferentRevAndPegString($passrev, $peg);
 				}
 
-				if ($treeview) {
+				if ($treeview) 
+				{
 					$listvar['compare_box'] = '<input type="checkbox" name="compare[]" value="'.escape($path.$file).'@'.$passrev.'" onclick="enforceOnlyTwoChecked(this)" />';
 				}
-				if ($config->showLastModInListing()) {
+
+				if ($config->showLastModInListing()) 
+				{
 					$listvar['committime'] = $entry->committime;
 					$listvar['revision'] = $entry->rev;
 					$listvar['author'] = $entry->author;
@@ -150,20 +185,30 @@ function showDirFiles($svnrep, $subs, $level, $limit, $rev, $peg, $listing, $ind
 					$listvar['date'] = $entry->date;
 					$listvar['revurl'] = $config->getURL($rep, $path.$file, 'revision').$isDirString.createRevAndPegString($entry->rev, $peg ? $peg : $rev);
 				}
-				if ($rep->isDownloadAllowed($path.$file)) {
+
+				if ($rep->isDownloadAllowed($path.$file)) 
+				{
 					$downloadurl = $config->getURL($rep, $path.$file, 'dl').$isDirString.$downloadRevAndPeg;
-					if ($isDir) {
+
+					if ($isDir) 
+					{
 						$listvar['downloadurl'] = $downloadurl;
 						$listvar['downloadplainurl'] = '';
-					} else {
+					}
+					else 
+					{
 						$listvar['downloadplainurl'] = $downloadurl;
 						$listvar['downloadurl'] = '';
 					}
-				} else {
+				} 
+				else 
+				{
 					$listvar['downloadplainurl'] = '';
 					$listvar['downloadurl'] = '';
 				}
-				if ($rep->isRssEnabled()) {
+
+				if ($rep->isRssEnabled()) 
+				{
 					// RSS should always point to the latest revision, so don't include rev
 					$listvar['rssurl'] = $config->getURL($rep, $path.$file, 'rss').$isDirString.createRevAndPegString('', $peg);
 				}
@@ -172,9 +217,11 @@ function showDirFiles($svnrep, $subs, $level, $limit, $rev, $peg, $listing, $ind
 				$index++;
 				$last_index = $index;
 
-				if ($isDir && ($level != $limit)) {
+				if ($isDir && ($level != $limit)) 
+				{
 					// @todo remove the alternate check with htmlentities when assured that there are not side effects
-					if (isset($subs[$level + 1]) && (!strcmp($subs[$level + 1].'/', $file) || !strcmp(htmlentities($subs[$level + 1], ENT_QUOTES).'/', htmlentities($file)))) {
+					if (isset($subs[$level + 1]) && (!strcmp($subs[$level + 1].'/', $file) || !strcmp(htmlentities($subs[$level + 1], ENT_QUOTES).'/', htmlentities($file)))) 
+					{
 						$listing = showDirFiles($svnrep, $subs, $level + 1, $limit, $rev, $peg, $listing, $index);
 						$index = count($listing);
 					}
@@ -184,14 +231,16 @@ function showDirFiles($svnrep, $subs, $level, $limit, $rev, $peg, $listing, $ind
 	}
 
 	// For an expanded tree, give the last entry an "L" node to close the grouping
-	if ($treeview && $last_index != 0) {
+	if ($treeview && $last_index != 0) 
+	{
 		$listing[$last_index - 1]['node'] = 1; // l-node
 	}
 
 	return $listing;
 }
 
-function showAllDirFiles($svnrep, $path, $rev, $peg, $listing, $index, $treeView = true) {
+function showAllDirFiles($svnrep, $path, $rev, $peg, $listing, $index, $treeView = true) 
+{
 	global $config, $lang, $rep, $passrev, $peg, $passRevString;
 
 	// List each file in the current directory
@@ -200,12 +249,14 @@ function showAllDirFiles($svnrep, $path, $rev, $peg, $listing, $index, $treeView
 	$accessToThisDir = $rep->hasReadAccess($path, false);
 
 	// If using flat view and not at the root, create a '..' entry at the top.
-	if (!$treeView && count($subs) > 2) {
+	if (!$treeView && count($subs) > 2) 
+	{
 		$parentPath = $subs;
 		unset($parentPath[count($parentPath) - 2]);
 		$parentPath = implode('/', $parentPath);
 
-		if ($rep->hasReadAccess($parentPath, false)) {
+		if ($rep->hasReadAccess($parentPath, false)) 
+		{
 			$listvar = &$listing[$index];
 			$listvar['rowparity'] = $index % 2;
 			$listvar['path'] = $parentPath;
@@ -227,13 +278,15 @@ function showAllDirFiles($svnrep, $path, $rev, $peg, $listing, $index, $treeView
 	$openDir = false;
 	$logList = $svnrep->getList($path, $rev, $peg);
 
-	if (!$logList) {
+	if (!$logList) 
+	{
 		return $listing;
 	}
 
 	$downloadRevAndPeg = createRevAndPegString($rev, $peg ? $peg : $rev);
 
-	foreach ($logList->entries as $entry) {
+	foreach ($logList->entries as $entry) 
+	{
 		$isDir = $entry->isdir;
 
 		$file = $entry->file;
@@ -243,17 +296,21 @@ function showAllDirFiles($svnrep, $path, $rev, $peg, $listing, $index, $treeView
 		$access = ($isDir)	? $rep->hasReadAccess($path.$file, false)
 							: $accessToThisDir;
 
-		if (!$access) {
+		if (!$access) 
+		{
 			continue;
 		}
 
 		$listvar = &$listing[$index];
 		$listvar['rowparity'] = $index % 2;
 
-		if ($isDir) {
+		if ($isDir) 
+		{
 			$listvar['filetype'] = 'dir';
 			$openDir = true;
-		} else {
+		} 
+		else 
+		{
 			$listvar['filetype'] = strtolower(strrchr($file, '.'));
 			$openDir = false;
 		}
@@ -297,25 +354,33 @@ function showAllDirFiles($svnrep, $path, $rev, $peg, $listing, $index, $treeView
 			$listvar['last_i_node'][$lastindexfile] = true;
 		}
 
-		if ($isDir) {
+		if ($isDir) 
+		{
 			$listvar['fileurl'] = urlForPath($path.$file, $passRevString);
-		} else {
+		} 
+		else 
+		{
 			$listvar['fileurl'] = urlForPath($path.$file, createDifferentRevAndPegString($passrev, $peg));
 		}
 
 		$listvar['filelink'] = '<a href="'.$listvar['fileurl'].'">'.$listvar['filename'].'</a>';
 
-		if ($isDir) {
+		if ($isDir) 
+		{
 			$listvar['logurl'] = $config->getURL($rep, $path.$file, 'log').$isDirString.$passRevString;
-		} else {
+		}
+		else 
+		{
 			$listvar['logurl'] = $config->getURL($rep, $path.$file, 'log').$isDirString.createDifferentRevAndPegString($passrev, $peg);
 		}
 
-		if ($treeView) {
+		if ($treeView) 
+		{
 			$listvar['compare_box'] = '<input type="checkbox" name="compare[]" value="'.escape($path.$file).'@'.$passrev.'" onclick="enforceOnlyTwoChecked(this)" />';
 		}
 
-		if ($config->showLastModInListing()) {
+		if ($config->showLastModInListing()) 
+		{
 			$listvar['committime'] = $entry->committime;
 			$listvar['revision'] = $entry->rev;
 			$listvar['author'] = $entry->author;
@@ -324,22 +389,29 @@ function showAllDirFiles($svnrep, $path, $rev, $peg, $listing, $index, $treeView
 			$listvar['revurl'] = $config->getURL($rep, $path.$file, 'revision').$isDirString.createRevAndPegString($entry->rev, $peg ? $peg : $rev);
 		}
 
-		if ($rep->isDownloadAllowed($path.$file)) {
+		if ($rep->isDownloadAllowed($path.$file)) 
+		{
 			$downloadurl = $config->getURL($rep, $path.$file, 'dl').$isDirString.$downloadRevAndPeg;
 
-			if ($isDir) {
+			if ($isDir) 
+			{
 				$listvar['downloadurl'] = $downloadurl;
 				$listvar['downloadplainurl'] = '';
-			} else {
+			}
+			else 
+			{
 				$listvar['downloadplainurl'] = $downloadurl;
 				$listvar['downloadurl'] = '';
 			}
-		} else {
+		} 
+		else 
+		{
 			$listvar['downloadplainurl'] = '';
 			$listvar['downloadurl'] = '';
 		}
 
-		if ($rep->isRssEnabled()) {
+		if ($rep->isRssEnabled()) 
+		{
 			// RSS should always point to the latest revision, so don't include rev
 			$listvar['rssurl'] = $config->getURL($rep, $path.$file, 'rss').$isDirString.createRevAndPegString('', $peg);
 		}
@@ -347,16 +419,17 @@ function showAllDirFiles($svnrep, $path, $rev, $peg, $listing, $index, $treeView
 		$loop++;
 		$index++;
 		$last_index = $index;
-
 	}
 
 	return $listing;
 }
 
-function showTreeDir($svnrep, $path, $rev, $peg, $listing) {
+function showTreeDir($svnrep, $path, $rev, $peg, $listing) 
+{
 	global $vars, $config;
 
-	if ($config->showLoadAllRepos()) {
+	if ($config->showLoadAllRepos()) 
+	{
 		$vars['compare_box'] = ''; // Set blank once in case tree view is not enabled.
 		return showAllDirFiles($svnrep, $path, $rev, $peg, $listing, 0, $config->treeView);
 	}
@@ -368,7 +441,8 @@ function showTreeDir($svnrep, $path, $rev, $peg, $listing) {
 	// Therefore, it is always count($subs) - 2
 	$limit = count($subs) - 2;
 
-	for ($n = 0; $n < $limit; $n++) {
+	for ($n = 0; $n < $limit; $n++) 
+	{
 		$vars['last_i_node'][$n] = false;
 	}
 

--- a/listing.php
+++ b/listing.php
@@ -379,7 +379,7 @@ function showTreeDir($svnrep, $path, $rev, $peg, $listing) {
 // Make sure that we have a repository
 if (!$rep)
 {
-	renderTemplateNoRepo('directory');
+	renderTemplate404('directory',$lang['NOREP']);
 }
 
 $svnrep = new SVNRepository($rep);

--- a/log.php
+++ b/log.php
@@ -97,7 +97,7 @@ $maxperpage = 20;
 // Make sure that we have a repository
 if (!$rep)
 {
-	renderTemplate404('log',$lang['NOREP']);
+	renderTemplate404('log','NOREP');
 }
 
 $svnrep = new SVNRepository($rep);
@@ -111,7 +111,7 @@ if (!$history)
 
 	if (!$history) 
 	{
-		renderTemplate404('log',$lang['NOPATH']);
+		renderTemplate404('log','NOPATH');
 	}
 }
 

--- a/log.php
+++ b/log.php
@@ -82,353 +82,464 @@ if ($dosearch)
 $maxperpage = 20;
 
 // Make sure that we have a repository
-if ($rep) {
-	$svnrep = new SVNRepository($rep);
+if (!$rep)
+{
+	renderTemplateNoRepo('log');
+}
 
-	$history = $svnrep->getLog($path, 'HEAD', '', false, 1, ($path == '/') ? '' : $peg);
-	if (!$history) {
+$svnrep = new SVNRepository($rep);
+
+$history = $svnrep->getLog($path, 'HEAD', '', false, 1, ($path == '/') ? '' : $peg);
+
+if (!$history) 
+{
+	unset($vars['error']);
+	$history = $svnrep->getLog($path, '', '', false, 1, ($path == '/') ? '' : $peg);
+
+	if (!$history) 
+	{
+		http_response_code(404);
+		$vars['error'] = $lang['NOPATH'];
+	}
+}
+
+$youngest = ($history && isset($history->entries[0])) ? $history->entries[0]->rev : 0;
+
+if (empty($startrev)) 
+{
+	//$startrev = ($rev) ? $rev : 'HEAD';
+	$startrev = $rev;
+}
+else if ($startrev != 'HEAD' && $startrev != 'BASE' && $startrev != 'PREV' && $startrev != 'COMMITTED') 
+{
+	$startrev = (int)$startrev;
+}
+
+if (empty($endrev)) 
+{
+	$endrev = 1;
+}
+else if ($endrev != 'HEAD' && $endrev != 'BASE' && $endrev != 'PREV' && $endrev != 'COMMITTED') 
+{
+	$endrev = (int)$endrev;
+}
+
+if (empty($rev)) 
+{
+	$rev = $youngest;
+}
+
+if (empty($startrev)) 
+{
+	$startrev = $rev;
+}
+
+// make sure path is prefixed by a /
+$ppath = $path;
+
+if ($path == '' || $path[0] != '/') 
+{
+	$ppath = '/'.$path;
+}
+
+$vars['action'] = $lang['LOG'];
+$vars['rev'] = $rev;
+$vars['peg'] = $peg;
+$vars['path'] = escape($ppath);
+
+if ($history && isset($history->entries[0])) 
+{
+	$vars['log'] = xml_entities($history->entries[0]->msg);
+	$vars['date'] = $history->entries[0]->date;
+	$vars['age'] = datetimeFormatDuration(time() - strtotime($history->entries[0]->date));
+	$vars['author'] = $history->entries[0]->author;
+}
+
+if ($max === false) 
+{
+	$max = ($dosearch) ? 0 : 40;
+}
+else if ($max < 0) 
+{
+	$max = 40;
+}
+
+// TODO: If the rev is less than the head, get the path (may have been renamed!)
+// Will probably need to call `svn info`, parse XML output, and substring a path
+
+createPathLinks($rep, $ppath, $passrev, $peg);
+$passRevString = createRevAndPegString($rev, $peg);
+$isDirString = ($isDir) ? 'isdir=1&amp;' : '';
+
+unset($queryParams['repname']);
+unset($queryParams['path']);
+
+// Toggle 'showchanges' param for link to switch from the current behavior
+if ($showchanges == $rep->logsShowChanges())
+{
+	$queryParams['showchanges'] = (int)!$showchanges;
+}
+else
+{
+	unset($queryParams['showchanges']);
+}
+
+$vars['changesurl'] = $config->getURL($rep, $path, 'log').buildQuery($queryParams);
+$vars['changeslink'] = '<a href="'.$vars['changesurl'].'">'.$lang[($showchanges ? 'HIDECHANGED' : 'SHOWCHANGED')].'</a>';
+$vars['showchanges'] = $showchanges;
+
+// Revert 'showchanges' param to propagate the current behavior
+if ($showchanges == $rep->logsShowChanges())
+{
+	unset($queryParams['showchanges']);
+}
+else
+{
+	$queryParams['showchanges'] = (int)$showchanges;
+}
+
+$vars['revurl'] = $config->getURL($rep, $path, 'revision').$isDirString.$passRevString;
+
+if ($isDir) 
+{
+	$vars['directoryurl'] = $config->getURL($rep, $path, 'dir').$passRevString.'#'.anchorForPath($path);
+	$vars['directorylink'] = '<a href="'.$vars['directoryurl'].'">'.$lang['LISTING'].'</a>';
+}
+else 
+{
+	$vars['filedetailurl'] = $config->getURL($rep, $path, 'file').$passRevString;
+	$vars['filedetaillink'] = '<a href="'.$vars['filedetailurl'].'">'.$lang['FILEDETAIL'].'</a>';
+
+	$vars['blameurl'] = $config->getURL($rep, $path, 'blame').$passRevString;
+	$vars['blamelink'] = '<a href="'.$vars['blameurl'].'">'.$lang['BLAME'].'</a>';
+
+	$vars['diffurl'] = $config->getURL($rep, $path, 'diff').$passRevString;
+	$vars['difflink'] = '<a href="'.$vars['diffurl'].'">'.$lang['DIFFPREV'].'</a>';
+}
+
+if ($rep->isRssEnabled()) 
+{
+	$vars['rssurl'] = $config->getURL($rep, $path, 'rss').$isDirString.createRevAndPegString('', $peg);
+	$vars['rsslink'] = '<a href="'.$vars['rssurl'].'">'.$lang['RSSFEED'].'</a>';
+}
+
+if ($rev != $youngest) 
+{
+	if ($path == '/') 
+	{
+		$vars['goyoungesturl'] = $config->getURL($rep, '', 'log').$isDirString;
+	}
+	else 
+	{
+		$vars['goyoungesturl'] = $config->getURL($rep, $path, 'log').$isDirString.'peg='.($peg ? $peg : $rev);
+	}
+
+	$vars['goyoungestlink'] = '<a href="'.$vars['goyoungesturl'].'"'.($youngest ? ' title="'.$lang['REV'].' '.$youngest.'"' : '').'>'.$lang['GOYOUNGEST'].'</a>';
+}
+
+// We get the bugtraq variable just once based on the HEAD
+$bugtraq = new Bugtraq($rep, $svnrep, $ppath);
+
+$vars['logsearch_moreresultslink'] = '';
+$vars['pagelinks'] = '';
+$vars['showalllink'] = '';
+
+if ($history) 
+{
+	$history = $svnrep->getLog($path, $startrev, $endrev, true, $max, $peg);
+
+	if (empty($history)) 
+	{
 		unset($vars['error']);
-		$history = $svnrep->getLog($path, '', '', false, 1, ($path == '/') ? '' : $peg);
-		if (!$history) {
-			http_response_code(404);
-			$vars['error'] = $lang['NOPATH'];
+		$vars['warning'] = 'Revision '.$startrev.' of this resource does not exist.';
+	}
+}
+
+if (!empty($history)) 
+{
+	// Get the number of separate revisions
+	$revisions = count($history->entries);
+
+	if ($all) 
+	{
+		$firstrevindex = 0;
+		$lastrevindex = $revisions - 1;
+		$pages = 1;
+	}
+	else 
+	{
+		// Calculate the number of pages
+		$pages = floor($revisions / $maxperpage);
+		if (($revisions % $maxperpage) > 0) $pages++;
+
+		if ($page > $pages) $page = $pages;
+
+		// Work out where to start and stop
+		$firstrevindex = ($page - 1) * $maxperpage;
+		$lastrevindex = min($firstrevindex + $maxperpage - 1, $revisions - 1);
+	}
+
+	$frev = isset($history->entries[0]) ? $history->entries[0]->rev : false;
+	$brev = isset($history->entries[$firstrevindex]) ? $history->entries[$firstrevindex]->rev : false;
+	$erev = isset($history->entries[$lastrevindex]) ? $history->entries[$lastrevindex]->rev : false;
+
+	$entries = array();
+
+	if ($brev && $erev) 
+	{
+		$history = $svnrep->getLog($path, $brev, $erev, false, 0, $peg, $showchanges);
+		if ($history)
+		{
+			$entries = $history->entries;
 		}
 	}
 
-	$youngest = ($history && isset($history->entries[0])) ? $history->entries[0]->rev : 0;
+	$row = 0;
+	$index = 0;
+	$found = false;
 
-	if (empty($startrev)) {
-	  //$startrev = ($rev) ? $rev : 'HEAD';
-		$startrev = $rev;
-	} else if ($startrev != 'HEAD' && $startrev != 'BASE' && $startrev != 'PREV' && $startrev != 'COMMITTED') {
-		$startrev = (int)$startrev;
-	}
-	if (empty($endrev)) {
-		$endrev = 1;
-	} else if ($endrev != 'HEAD' && $endrev != 'BASE' && $endrev != 'PREV' && $endrev != 'COMMITTED') {
-		$endrev = (int)$endrev;
-	}
+	foreach ($entries as $revision) 
+	{
+		// Assume a good match
+		$match = true;
+		$thisrev = $revision->rev;
 
-	if (empty($rev)) {
-		$rev = $youngest;
-	}
+		// Check the log for the search words, if searching
+		if ($dosearch) 
+		{
+			if ((empty($fromRev) || $fromRev > $thisrev)) 
+			{
+				// Turn all the HTML entities into real characters.
 
-	if (empty($startrev)) {
-		$startrev = $rev;
-	}
-
-	// make sure path is prefixed by a /
-	$ppath = $path;
-	if ($path == '' || $path[0] != '/') {
-		$ppath = '/'.$path;
-	}
-
-	$vars['action'] = $lang['LOG'];
-	$vars['rev'] = $rev;
-	$vars['peg'] = $peg;
-	$vars['path'] = escape($ppath);
-
-	if ($history && isset($history->entries[0])) {
-		$vars['log'] = xml_entities($history->entries[0]->msg);
-		$vars['date'] = $history->entries[0]->date;
-		$vars['age'] = datetimeFormatDuration(time() - strtotime($history->entries[0]->date));
-		$vars['author'] = $history->entries[0]->author;
-	}
-
-	if ($max === false) {
-		$max = ($dosearch) ? 0 : 40;
-	} else if ($max < 0) {
-		$max = 40;
-	}
-
-	// TODO: If the rev is less than the head, get the path (may have been renamed!)
-	// Will probably need to call `svn info`, parse XML output, and substring a path
-
-	createPathLinks($rep, $ppath, $passrev, $peg);
-	$passRevString = createRevAndPegString($rev, $peg);
-	$isDirString = ($isDir) ? 'isdir=1&amp;' : '';
-
-	unset($queryParams['repname']);
-	unset($queryParams['path']);
-	// Toggle 'showchanges' param for link to switch from the current behavior
-	if ($showchanges == $rep->logsShowChanges())
-		$queryParams['showchanges'] = (int)!$showchanges;
-	else
-		unset($queryParams['showchanges']);
-	$vars['changesurl'] = $config->getURL($rep, $path, 'log').buildQuery($queryParams);
-	$vars['changeslink'] = '<a href="'.$vars['changesurl'].'">'.$lang[($showchanges ? 'HIDECHANGED' : 'SHOWCHANGED')].'</a>';
-	$vars['showchanges'] = $showchanges;
-	// Revert 'showchanges' param to propagate the current behavior
-	if ($showchanges == $rep->logsShowChanges())
-		unset($queryParams['showchanges']);
-	else
-		$queryParams['showchanges'] = (int)$showchanges;
-
-	$vars['revurl'] = $config->getURL($rep, $path, 'revision').$isDirString.$passRevString;
-	if ($isDir) {
-		$vars['directoryurl'] = $config->getURL($rep, $path, 'dir').$passRevString.'#'.anchorForPath($path);
-		$vars['directorylink'] = '<a href="'.$vars['directoryurl'].'">'.$lang['LISTING'].'</a>';
-	} else {
-		$vars['filedetailurl'] = $config->getURL($rep, $path, 'file').$passRevString;
-		$vars['filedetaillink'] = '<a href="'.$vars['filedetailurl'].'">'.$lang['FILEDETAIL'].'</a>';
-
-		$vars['blameurl'] = $config->getURL($rep, $path, 'blame').$passRevString;
-		$vars['blamelink'] = '<a href="'.$vars['blameurl'].'">'.$lang['BLAME'].'</a>';
-
-		$vars['diffurl'] = $config->getURL($rep, $path, 'diff').$passRevString;
-		$vars['difflink'] = '<a href="'.$vars['diffurl'].'">'.$lang['DIFFPREV'].'</a>';
-	}
-
-	if ($rep->isRssEnabled()) {
-		$vars['rssurl'] = $config->getURL($rep, $path, 'rss').$isDirString.createRevAndPegString('', $peg);
-		$vars['rsslink'] = '<a href="'.$vars['rssurl'].'">'.$lang['RSSFEED'].'</a>';
-	}
-
-	if ($rev != $youngest) {
-		if ($path == '/') {
-			$vars['goyoungesturl'] = $config->getURL($rep, '', 'log').$isDirString;
-		} else {
-			$vars['goyoungesturl'] = $config->getURL($rep, $path, 'log').$isDirString.'peg='.($peg ? $peg : $rev);
-		}
-		$vars['goyoungestlink'] = '<a href="'.$vars['goyoungesturl'].'"'.($youngest ? ' title="'.$lang['REV'].' '.$youngest.'"' : '').'>'.$lang['GOYOUNGEST'].'</a>';
-	}
-
-	// We get the bugtraq variable just once based on the HEAD
-	$bugtraq = new Bugtraq($rep, $svnrep, $ppath);
-
-	$vars['logsearch_moreresultslink'] = '';
-	$vars['pagelinks'] = '';
-	$vars['showalllink'] = '';
-
-	if ($history) {
-		$history = $svnrep->getLog($path, $startrev, $endrev, true, $max, $peg);
-		if (empty($history)) {
-			unset($vars['error']);
-			$vars['warning'] = 'Revision '.$startrev.' of this resource does not exist.';
-		}
-	}
-	if (!empty($history)) {
-		// Get the number of separate revisions
-		$revisions = count($history->entries);
-
-		if ($all) {
-			$firstrevindex = 0;
-			$lastrevindex = $revisions - 1;
-			$pages = 1;
-		} else {
-			// Calculate the number of pages
-			$pages = floor($revisions / $maxperpage);
-			if (($revisions % $maxperpage) > 0) $pages++;
-
-			if ($page > $pages) $page = $pages;
-
-			// Work out where to start and stop
-			$firstrevindex = ($page - 1) * $maxperpage;
-			$lastrevindex = min($firstrevindex + $maxperpage - 1, $revisions - 1);
-		}
-
-		$frev = isset($history->entries[0]) ? $history->entries[0]->rev : false;
-		$brev = isset($history->entries[$firstrevindex]) ? $history->entries[$firstrevindex]->rev : false;
-		$erev = isset($history->entries[$lastrevindex]) ? $history->entries[$lastrevindex]->rev : false;
-
-		$entries = array();
-		if ($brev && $erev) {
-			$history = $svnrep->getLog($path, $brev, $erev, false, 0, $peg, $showchanges);
-			if ($history)
-				$entries = $history->entries;
-		}
-
-		$row = 0;
-		$index = 0;
-		$found = false;
-
-		foreach ($entries as $revision) {
-			// Assume a good match
-			$match = true;
-			$thisrev = $revision->rev;
-
-			// Check the log for the search words, if searching
-			if ($dosearch) {
-				if ((empty($fromRev) || $fromRev > $thisrev)) {
-					// Turn all the HTML entities into real characters.
-
-					// Make sure that each word in the search in also in the log
-					foreach ($words as $word) {
-						if (strpos(strtolower(removeAccents($revision->msg)), $word) === false && strpos(strtolower(removeAccents($revision->author)), $word) === false) {
-							$match = false;
-							break;
-						}
+				// Make sure that each word in the search in also in the log
+				foreach ($words as $word) 
+				{
+					if (strpos(strtolower(removeAccents($revision->msg)), $word) === false && strpos(strtolower(removeAccents($revision->author)), $word) === false) 
+					{
+						$match = false;
+						break;
 					}
-
-					if ($match) {
-						$numSearchResults--;
-						$found = true;
-					}
-				} else {
-					$match = false;
-				}
-			}
-
-			$thisRevString = createRevAndPegString($thisrev, ($peg ? $peg : $thisrev));
-
-			if ($match) {
-				// Add the trailing slash if we need to (svnlook history doesn't return trailing slashes!)
-				$rpath = $revision->path;
-				if (empty($rpath)) {
-					$rpath = '/';
-				} else if ($isDir && $rpath[strlen($rpath) - 1] != '/') {
-					$rpath .= '/';
 				}
 
-				$precisePath = $revision->precisePath;
-				if (empty($precisePath)) {
-					$precisePath = '/';
-				} else if ($isDir && $precisePath[strlen($precisePath) - 1] != '/') {
-					$precisePath .= '/';
+				if ($match) 
+				{
+					$numSearchResults--;
+					$found = true;
 				}
-
-				// Find the parent path (or the whole path if it's already a directory)
-				$pos = strrpos($rpath, '/');
-				$parent = substr($rpath, 0, $pos + 1);
-
-				$compareValue = (($isDir) ? $parent : $rpath).'@'.$thisrev;
-
-				$listvar = &$listing[$index];
-				$listvar['compare_box'] = '<input type="checkbox" name="compare[]" value="'.$compareValue.'" onclick="enforceOnlyTwoChecked(this)" />';
-				$url = $config->getURL($rep, $rpath, 'revision').$thisRevString;
-				$listvar['revlink'] = '<a href="'.$url.'">'.$thisrev.'</a>';
-
-				$url = $config->getURL($rep, $precisePath, ($isDir ? 'dir' : 'file')).$thisRevString;
-
-				$listvar['revpathlink'] = '<a href="'.$url.'">'.$precisePath.'</a>';
-				$listvar['revpath'] = $precisePath;
-				$listvar['revauthor'] = $revision->author;
-				$listvar['revdate'] = $revision->date;
-				$listvar['revage'] = $revision->age;
-				$listvar['revlog'] = nl2br($bugtraq->replaceIDs(create_anchors(xml_entities($revision->msg))));
-				$listvar['rowparity'] = $row;
-				$listvar['compareurl'] = $config->getURL($rep, '', 'comp').'compare[]='.urlencode($rpath).'@'.($thisrev - 1).'&amp;compare[]='.urlencode($rpath).'@'.$thisrev;
-
-				if ($showchanges) {
-					// Aggregate added/deleted/modified paths for display in table
-					$modpaths = array();
-					foreach ($revision->mods as $mod) {
-						$modpaths[$mod->action][] = $mod->path;
-					}
-					ksort($modpaths);
-					foreach ($modpaths as $action => $paths) {
-						sort($paths);
-						$modpaths[$action] = $paths;
-					}
-
-					$listvar['revadded'] = (isset($modpaths['A'])) ? implode('<br/>', escape($modpaths['A'])) : '';
-					$listvar['revdeleted'] = (isset($modpaths['D'])) ? implode('<br/>', escape($modpaths['D'])) : '';
-					$listvar['revmodified'] = (isset($modpaths['M'])) ? implode('<br/>', escape($modpaths['M'])) : '';
-				}
-
-				$row = 1 - $row;
-				$index++;
-			}
-
-			// If we've reached the search limit, stop here...
-			if (!$numSearchResults) {
-				$url = $config->getURL($rep, $path, 'log').$isDirString.$thisRevString;
-				$vars['logsearch_moreresultslink'] = '<a href="'.$url.'&amp;search='.$search.'&amp;fr='.$thisrev.'">'.$lang['MORERESULTS'].'</a>';
-				break;
+			} 
+			else 
+			{
+				$match = false;
 			}
 		}
 
-		$vars['logsearch_resultsfound'] = true;
+		$thisRevString = createRevAndPegString($thisrev, ($peg ? $peg : $thisrev));
 
-		if ($dosearch && !$found) {
-			if ($fromRev == 0) {
-				$vars['logsearch_nomatches'] = true;
-				$vars['logsearch_resultsfound'] = false;
-			} else {
-				$vars['logsearch_nomorematches'] = true;
+		if ($match) 
+		{
+			// Add the trailing slash if we need to (svnlook history doesn't return trailing slashes!)
+			$rpath = $revision->path;
+
+			if (empty($rpath)) 
+			{
+				$rpath = '/';
 			}
-		} else if ($dosearch && $numSearchResults > 0) {
+			else if ($isDir && $rpath[strlen($rpath) - 1] != '/') 
+			{
+				$rpath .= '/';
+			}
+
+			$precisePath = $revision->precisePath;
+			if (empty($precisePath)) 
+			{
+				$precisePath = '/';
+			}
+			else if ($isDir && $precisePath[strlen($precisePath) - 1] != '/') 
+			{
+				$precisePath .= '/';
+			}
+
+			// Find the parent path (or the whole path if it's already a directory)
+			$pos = strrpos($rpath, '/');
+			$parent = substr($rpath, 0, $pos + 1);
+
+			$compareValue = (($isDir) ? $parent : $rpath).'@'.$thisrev;
+
+			$listvar = &$listing[$index];
+			$listvar['compare_box'] = '<input type="checkbox" name="compare[]" value="'.$compareValue.'" onclick="enforceOnlyTwoChecked(this)" />';
+			$url = $config->getURL($rep, $rpath, 'revision').$thisRevString;
+			$listvar['revlink'] = '<a href="'.$url.'">'.$thisrev.'</a>';
+
+			$url = $config->getURL($rep, $precisePath, ($isDir ? 'dir' : 'file')).$thisRevString;
+
+			$listvar['revpathlink'] = '<a href="'.$url.'">'.$precisePath.'</a>';
+			$listvar['revpath'] = $precisePath;
+			$listvar['revauthor'] = $revision->author;
+			$listvar['revdate'] = $revision->date;
+			$listvar['revage'] = $revision->age;
+			$listvar['revlog'] = nl2br($bugtraq->replaceIDs(create_anchors(xml_entities($revision->msg))));
+			$listvar['rowparity'] = $row;
+			$listvar['compareurl'] = $config->getURL($rep, '', 'comp').'compare[]='.urlencode($rpath).'@'.($thisrev - 1).'&amp;compare[]='.urlencode($rpath).'@'.$thisrev;
+
+			if ($showchanges) 
+			{
+				// Aggregate added/deleted/modified paths for display in table
+				$modpaths = array();
+
+				foreach ($revision->mods as $mod) 
+				{
+					$modpaths[$mod->action][] = $mod->path;
+				}
+
+				ksort($modpaths);
+
+				foreach ($modpaths as $action => $paths) 
+				{
+					sort($paths);
+					$modpaths[$action] = $paths;
+				}
+
+				$listvar['revadded'] = (isset($modpaths['A'])) ? implode('<br/>', escape($modpaths['A'])) : '';
+				$listvar['revdeleted'] = (isset($modpaths['D'])) ? implode('<br/>', escape($modpaths['D'])) : '';
+				$listvar['revmodified'] = (isset($modpaths['M'])) ? implode('<br/>', escape($modpaths['M'])) : '';
+			}
+
+			$row = 1 - $row;
+			$index++;
+		}
+
+		// If we've reached the search limit, stop here...
+		if (!$numSearchResults) 
+		{
+			$url = $config->getURL($rep, $path, 'log').$isDirString.$thisRevString;
+			$vars['logsearch_moreresultslink'] = '<a href="'.$url.'&amp;search='.$search.'&amp;fr='.$thisrev.'">'.$lang['MORERESULTS'].'</a>';
+			break;
+		}
+	}
+
+	$vars['logsearch_resultsfound'] = true;
+
+	if ($dosearch && !$found) 
+	{
+		if ($fromRev == 0) 
+		{
+			$vars['logsearch_nomatches'] = true;
+			$vars['logsearch_resultsfound'] = false;
+		} 
+		else 
+		{
 			$vars['logsearch_nomorematches'] = true;
 		}
+	} 
+	else if ($dosearch && $numSearchResults > 0) 
+	{
+		$vars['logsearch_nomorematches'] = true;
+	}
 
-		// Work out the paging options, create links to pages of results
-		if ($pages > 1) {
-			$prev = $page - 1;
-			$next = $page + 1;
+	// Work out the paging options, create links to pages of results
+	if ($pages > 1) 
+	{
+		$prev = $page - 1;
+		$next = $page + 1;
 
-			unset($queryParams['page']);
-			$logurl = $config->getURL($rep, $path, 'log').buildQuery($queryParams);
+		unset($queryParams['page']);
+		$logurl = $config->getURL($rep, $path, 'log').buildQuery($queryParams);
 
-			if ($page > 1) {
-				$vars['pagelinks'] .= '<a href="'.$logurl.(!$peg && $frev && $prev != 1 ? '&amp;peg='.$frev : '').'&amp;page='.$prev.'">&larr;'.$lang['PREV'].'</a>';
-			} else {
-				$vars['pagelinks'] .= '<span>&larr;'.$lang['PREV'].'</span>';
-			}
-
-			for ($p = 1; $p <= $pages; $p++) {
-				if ($p != $page) {
-					$vars['pagelinks'] .= '<a href="'.$logurl.(!$peg && $frev && $p != 1 ? '&amp;peg='.$frev : '').'&amp;page='.$p.'">'.$p.'</a>';
-				} else {
-					$vars['pagelinks'] .= '<span id="curpage">'.$p.'</span>';
-				}
-			}
-
-			if ($page < $pages) {
-				$vars['pagelinks'] .= '<a href="'.$logurl.(!$peg && $frev ? '&amp;peg='.$frev : '').'&amp;page='.$next.'">'.$lang['NEXT'].'&rarr;</a>';
-			} else {
-				$vars['pagelinks'] .= '<span>'.$lang['NEXT'].'&rarr;</span>';
-			}
-
-			$vars['showalllink'] = '<a href="'.$logurl.'&amp;all=1">'.$lang['SHOWALL'].'</a>';
+		if ($page > 1) 
+		{
+			$vars['pagelinks'] .= '<a href="'.$logurl.(!$peg && $frev && $prev != 1 ? '&amp;peg='.$frev : '').'&amp;page='.$prev.'">&larr;'.$lang['PREV'].'</a>';
 		}
+		else 
+		{
+			$vars['pagelinks'] .= '<span>&larr;'.$lang['PREV'].'</span>';
+		}
+
+		for ($p = 1; $p <= $pages; $p++) 
+		{
+			if ($p != $page) 
+			{
+				$vars['pagelinks'] .= '<a href="'.$logurl.(!$peg && $frev && $p != 1 ? '&amp;peg='.$frev : '').'&amp;page='.$p.'">'.$p.'</a>';
+			} 
+			else 
+			{
+				$vars['pagelinks'] .= '<span id="curpage">'.$p.'</span>';
+			}
+		}
+
+		if ($page < $pages) 
+		{
+			$vars['pagelinks'] .= '<a href="'.$logurl.(!$peg && $frev ? '&amp;peg='.$frev : '').'&amp;page='.$next.'">'.$lang['NEXT'].'&rarr;</a>';
+		}
+		else 
+		{
+			$vars['pagelinks'] .= '<span>'.$lang['NEXT'].'&rarr;</span>';
+		}
+
+		$vars['showalllink'] = '<a href="'.$logurl.'&amp;all=1">'.$lang['SHOWALL'].'</a>';
 	}
+}
 
-	// Create form elements for filtering and searching log messages
-	if ($config->multiViews) {
-		$hidden = '<input type="hidden" name="op" value="log" />';
-	} else {
-		$hidden = '<input type="hidden" name="repname" value="'.$repname.'" />';
-		$hidden .= '<input type="hidden" name="path" value="'.$path.'" />';
-	}
-	if ($isDir)
-		$hidden .= '<input type="hidden" name="isdir" value="'.$isDir.'" />';
-	if ($peg)
-		$hidden .= '<input type="hidden" name="peg" value="'.$peg.'" />';
-	if ($showchanges != $rep->logsShowChanges())
-		$hidden .= '<input type="hidden" name="showchanges" value="'.$showchanges.'" />';
+// Create form elements for filtering and searching log messages
+if ($config->multiViews) 
+{
+	$hidden = '<input type="hidden" name="op" value="log" />';
+}
+else 
+{
+	$hidden = '<input type="hidden" name="repname" value="'.$repname.'" />';
+	$hidden .= '<input type="hidden" name="path" value="'.$path.'" />';
+}
 
-	$vars['logsearch_form'] = '<form method="get" action="'.$config->getURL($rep, $path, 'log').'" id="search">'.$hidden;
-	$vars['logsearch_startbox'] = '<input name="sr" size="5" value="'.$startrev.'" />';
-	$vars['logsearch_endbox'] = '<input name="er" size="5" value="'.$endrev.'" />';
-	$vars['logsearch_maxbox'] = '<input name="max" size="5" value="'.($max == 0 ? 40 : $max).'" />';
-	$vars['logsearch_inputbox'] = '<input name="search" value="'.escape($search).'" />';
-	$vars['logsearch_showall'] = '<input type="checkbox" name="all" value="1"'.($all ? ' checked="checked"' : '').' />';
-	$vars['logsearch_submit'] = '<input type="submit" value="'.$lang['GO'].'" />';
-	$vars['logsearch_endform'] = '</form>';
+if ($isDir)
+{
+	$hidden .= '<input type="hidden" name="isdir" value="'.$isDir.'" />';
+}
 
-	// If a filter is in place, produce a link to clear all filter parameters
-	if ($page !== 1 || $all || $dosearch || $fromRev || $startrev !== $rev || $endrev !== 1 || $max !== 40) {
-		$url = $config->getURL($rep, $path, 'log').$isDirString.$passRevString;
-		$vars['logsearch_clearloglink'] = '<a href="'.$url.'">'.$lang['CLEARLOG'].'</a>';
-	}
+if ($peg)
+{
+	$hidden .= '<input type="hidden" name="peg" value="'.$peg.'" />';
+}
 
-	// Create form elements for comparing selected revisions
-	$vars['compare_form'] = '<form method="get" action="'.$config->getURL($rep, '', 'comp').'" id="compare">';
-	if ($config->multiViews) {
-		$vars['compare_form'] .= '<input type="hidden" name="op" value="comp" />';
-	} else {
-		$vars['compare_form'] .= '<input type="hidden" name="repname" value="'.$repname.'" />';
-	}
-	$vars['compare_submit'] = '<input type="submit" value="'.$lang['COMPAREREVS'].'" />';
-	$vars['compare_endform'] = '</form>';
+if ($showchanges != $rep->logsShowChanges())
+{
+	$hidden .= '<input type="hidden" name="showchanges" value="'.$showchanges.'" />';
+}
 
-	if (!$rep->hasReadAccess($path, false)) {
-		$vars['error'] = $lang['NOACCESS'];
-		sendHeaderForbidden();
-	}
+$vars['logsearch_form'] = '<form method="get" action="'.$config->getURL($rep, $path, 'log').'" id="search">'.$hidden;
+$vars['logsearch_startbox'] = '<input name="sr" size="5" value="'.$startrev.'" />';
+$vars['logsearch_endbox'] = '<input name="er" size="5" value="'.$endrev.'" />';
+$vars['logsearch_maxbox'] = '<input name="max" size="5" value="'.($max == 0 ? 40 : $max).'" />';
+$vars['logsearch_inputbox'] = '<input name="search" value="'.escape($search).'" />';
+$vars['logsearch_showall'] = '<input type="checkbox" name="all" value="1"'.($all ? ' checked="checked"' : '').' />';
+$vars['logsearch_submit'] = '<input type="submit" value="'.$lang['GO'].'" />';
+$vars['logsearch_endform'] = '</form>';
 
-} else {
-	http_response_code(404);
+// If a filter is in place, produce a link to clear all filter parameters
+if ($page !== 1 || $all || $dosearch || $fromRev || $startrev !== $rev || $endrev !== 1 || $max !== 40) 
+{
+	$url = $config->getURL($rep, $path, 'log').$isDirString.$passRevString;
+	$vars['logsearch_clearloglink'] = '<a href="'.$url.'">'.$lang['CLEARLOG'].'</a>';
+}
+
+// Create form elements for comparing selected revisions
+$vars['compare_form'] = '<form method="get" action="'.$config->getURL($rep, '', 'comp').'" id="compare">';
+
+if ($config->multiViews) 
+{
+	$vars['compare_form'] .= '<input type="hidden" name="op" value="comp" />';
+}
+else
+{
+	$vars['compare_form'] .= '<input type="hidden" name="repname" value="'.$repname.'" />';
+}
+
+$vars['compare_submit'] = '<input type="submit" value="'.$lang['COMPAREREVS'].'" />';
+$vars['compare_endform'] = '</form>';
+
+if (!$rep->hasReadAccess($path, false)) 
+{
+	$vars['error'] = $lang['NOACCESS'];
+	sendHeaderForbidden();
 }
 
 renderTemplate('log');

--- a/log.php
+++ b/log.php
@@ -98,8 +98,7 @@ if (!$history)
 
 	if (!$history) 
 	{
-		http_response_code(404);
-		$vars['error'] = $lang['NOPATH'];
+		renderTemplate404('log',$lang['NOPATH']);
 	}
 }
 

--- a/log.php
+++ b/log.php
@@ -31,10 +31,16 @@ require_once 'include/bugtraq.php';
 $page = (int)@$_REQUEST['page'];
 $all = @$_REQUEST['all'] == 1;
 $isDir = @$_REQUEST['isdir'] == 1 || $path == '' || $path == '/';
+
 if (isset($_REQUEST['showchanges']))
+{
 	$showchanges = @$_REQUEST['showchanges'] == 1;
+}
 else
+{
 	$showchanges = $rep->logsShowChanges();
+}
+
 $search = trim(@$_REQUEST['search']);
 $dosearch = strlen($search) > 0;
 
@@ -47,7 +53,8 @@ $max = isset($_REQUEST['max']) ? (int)$_REQUEST['max'] : false;
 // Max number of results to find at a time
 $numSearchResults = 20;
 
-if ($search == '') {
+if ($search == '') 
+{
 	$dosearch = false;
 }
 
@@ -57,14 +64,16 @@ if ($search == '') {
 // ideal, but expecting everyone to install 'unac' seems a little
 // excessive as well...
 
-function removeAccents($string) {
+function removeAccents($string) 
+{
 	$string = htmlentities($string, ENT_QUOTES, 'ISO-8859-1');
 	$string = preg_replace('/&([A-Za-z])(acute|uml|circ|grave|ring|cedil|slash|tilde|caron);/', '$1', $string);
 	return $string;
 }
 
 // Normalise the search words
-foreach ($words as $index => $word) {
+foreach ($words as $index => $word) 
+{
 	$words[$index] = strtolower(removeAccents($word));
 
 	// Remove empty string introduced by multiple spaces
@@ -73,11 +82,15 @@ foreach ($words as $index => $word) {
 }
 
 if (empty($page))
+{
 	$page = 1;
+}
 
 // If searching, display all the results
 if ($dosearch)
+{
 	$all = true;
+}
 
 $maxperpage = 20;
 

--- a/log.php
+++ b/log.php
@@ -84,7 +84,7 @@ $maxperpage = 20;
 // Make sure that we have a repository
 if (!$rep)
 {
-	renderTemplateNoRepo('log');
+	renderTemplate404('log',$lang['NOREP']);
 }
 
 $svnrep = new SVNRepository($rep);

--- a/revision.php
+++ b/revision.php
@@ -29,156 +29,193 @@ require_once 'include/template.php';
 require_once 'include/bugtraq.php';
 
 // Make sure that we have a repository
-if ($rep) {
-	$svnrep = new SVNRepository($rep);
+if (!$rep)
+{
+	renderTemplateNoRepo('revision');
+}
 
-	$ppath = ($path == '' || $path[0] != '/') ? '/'.$path : $path;
-	createPathLinks($rep, $ppath, $rev, $peg);
-	$passRevString = createRevAndPegString($rev, $peg);
+$svnrep = new SVNRepository($rep);
 
-	// Find the youngest revision containing changes for the given path
-	$history = $svnrep->getLog($path, 'HEAD', 1, true, 2, ($path == '/') ? '' : $peg);
-	if (!$history) {
-		unset($vars['error']);
-		$history = $svnrep->getLog($path, '', '', true, 2, ($path == '/') ? '' : $peg);
-		if (!$history) {
-			http_response_code(404);
-			$vars['error'] = $lang['NOPATH'];
-		}
-	}
-	$youngest = ($history && isset($history->entries[0])) ? $history->entries[0]->rev : 0;
-	$vars['youngestrev'] = $youngest;
+$ppath = ($path == '' || $path[0] != '/') ? '/'.$path : $path;
+createPathLinks($rep, $ppath, $rev, $peg);
+$passRevString = createRevAndPegString($rev, $peg);
 
-	// TODO The "youngest" rev is often incorrect when both path and rev are specified.
-	// If a path was last modified at rev M and the URL contains rev N, it uses rev N.
+// Find the youngest revision containing changes for the given path
+$history = $svnrep->getLog($path, 'HEAD', 1, true, 2, ($path == '/') ? '' : $peg);
 
-	// Unless otherwise specified, we get the log details of the latest change
-	$lastChangedRev = ($rev) ? $rev : $youngest;
-	$history = $svnrep->getLog($path, $lastChangedRev, 1, false, 2, $peg, true);
-	if (!$history) {
+if (!$history) 
+{
+	unset($vars['error']);
+	$history = $svnrep->getLog($path, '', '', true, 2, ($path == '/') ? '' : $peg);
+
+	if (!$history) 
+	{
 		http_response_code(404);
 		$vars['error'] = $lang['NOPATH'];
 	}
-	if (empty($rev))
-		$rev = $lastChangedRev;
-
-	// Generate links to newer and older revisions
-	$revurl = $config->getURL($rep, $path, 'revision');
-	if ($rev < $youngest) {
-		$vars['goyoungesturl'] = $config->getURL($rep, $path, 'revision');
-		$vars['goyoungestlink'] = '<a href="'.$vars['goyoungesturl'].'"'.($youngest ? ' title="'.$lang['REV'].' '.$youngest.'"' : '').'>'.$lang['GOYOUNGEST'].'</a>';
-
-		$history2 = $svnrep->getLog($path, $rev, $youngest, true, 2, $peg);
-		if (isset($history2->entries[1])) {
-			$nextRev = $history2->entries[1]->rev;
-			if ($nextRev != $youngest) {
-				$vars['nextrev'] = $nextRev;
-				$vars['nextrevurl'] = $revurl.createRevAndPegString($nextRev, $path != '/' ? $peg ? $peg : $rev : '');
-				//echo 'NEXT='.$vars['nextrevurl'].'<br/>';
-			}
-		}
-		unset($vars['error']);
-	}
-	if (isset($history->entries[1])) {
-		$prevRev = $history->entries[1]->rev;
-		$prevPath = $history->entries[1]->path;
-		$vars['prevrev'] = $prevRev;
-		$vars['prevrevurl'] = $revurl.createRevAndPegString($prevRev, $path != '/' ? ($peg ? $peg : $rev) : '');
-		//echo 'PREV='.$vars['prevrevurl'].'<br/>';
-	}
-	// Save the entry from which we pull information for the current revision.
-	$logEntry = (isset($history->entries[0])) ? $history->entries[0] : null;
-
-	$bugtraq = new Bugtraq($rep, $svnrep, $ppath);
-
-	$vars['action'] = '';
-	$vars['rev'] = $rev;
-	$vars['peg'] = $peg;
-	$vars['path'] = escape($ppath);
-	if ($logEntry) {
-		$vars['date'] = $logEntry->date;
-		$vars['age'] = datetimeFormatDuration(time() - strtotime($logEntry->date));
-		$vars['author'] = $logEntry->author;
-		$vars['log'] = nl2br($bugtraq->replaceIDs(create_anchors(xml_entities($logEntry->msg))));
-	}
-
-	$isDir = @$_REQUEST['isdir'] == 1 || $path == '' || $path == '/';
-	$vars['logurl'] = $config->getURL($rep, $path, 'log').$passRevString.($isDir ?  '&amp;isdir=1' : '');
-	$vars['loglink'] = '<a href="'.$vars['logurl'].'">'.$lang['VIEWLOG'].'</a>';
-
-	$dirPath = $isDir ? $path : dirname($path).'/';
-	$vars['directoryurl'] = $config->getURL($rep, $dirPath, 'dir').$passRevString.'#'.anchorForPath($dirPath);
-	$vars['directorylink'] = '<a href="'.$vars['directoryurl'].'">'.$lang['LISTING'].'</a>';
-
-	if ($path != $dirPath) {
-		$vars['filedetailurl'] = $config->getURL($rep, $path, 'file').$passRevString;
-		$vars['filedetaillink'] = '<a href="'.$vars['filedetailurl'].'">'.$lang['FILEDETAIL'].'</a>';
-		$vars['blameurl'] = $config->getURL($rep, $path, 'blame').$passRevString;
-		$vars['blamelink'] = '<a href="'.$vars['blameurl'].'">'.$lang['BLAME'].'</a>';
-	}
-
-	if ($rep->isRssEnabled()) {
-		$vars['rssurl'] = $config->getURL($rep, $path, 'rss').createRevAndPegString('', $peg);
-		$vars['rsslink'] = '<a href="'.$vars['rssurl'].'">'.$lang['RSSFEED'].'</a>';
-	}
-
-	$changes = $logEntry ? $logEntry->mods : array();
-	if (!is_array($changes)) {
-		$changes = array();
-	}
-	usort($changes, 'SVNLogEntry_compare');
-
-	$row = 0;
-
-	$prevRevString = createRevAndPegString($rev - 1, $rev - 1);
-	$thisRevString = createRevAndPegString($rev, $rev);
-	foreach ($changes as $change) {
-		$linkRevString = ($change->action == 'D') ? $prevRevString : $thisRevString;
-		$isDir = $change->isdir;
-		if ($isDir !== null) {
-			$isFile = !$isDir;
-		} else {
-			// NOTE: This is a hack (runs `svn info` on each path) to see if it's a file.
-			// `svn log --verbose --xml` should really provide this info, but does only in recent version?
-			$lastSeenRev = ($change->action == 'D') ? $rev - 1 : $rev;
-			$isFile = $svnrep->isFile($change->path, $lastSeenRev, $lastSeenRev);
-		}
-		if (!$isFile && $change->path != '/') {
-			$change->path .= '/';
-		}
-		$resourceExisted = $change->action == 'M' || $change->copyfrom;
-		$listing[] = array(
-			'path' => escape($change->path),
-			'oldpath' => $change->copyfrom ? $change->copyfrom.' @ '.$change->copyrev : '',
-			'action' => $change->action,
-			'added' => $change->action == 'A',
-			'deleted' => $change->action == 'D',
-			'modified' => $change->action == 'M',
-			'detailurl' => $config->getURL($rep, $change->path, ($isFile ? 'file' : 'dir')).$linkRevString,
-			// For deleted resources, the log link points to the previous revision.
-			'logurl' => $config->getURL($rep, $change->path, 'log').$linkRevString.($isFile ? '' : '&amp;isdir=1'),
-			'diffurl' => $resourceExisted ? $config->getURL($rep, $change->path, 'diff').$linkRevString : '',
-			'blameurl' => $resourceExisted ? $config->getURL($rep, $change->path, 'blame').$linkRevString : '',
-			'rowparity' => $row,
-			'notinpath' => substr($change->path, 0, strlen($path)) != $path,
-		);
-
-		$row = 1 - $row;
-	}
-
-	if (isset($prevRev)) {
-		$vars['compareurl'] = $config->getURL($rep, '', 'comp').'compare[]='.urlencode($prevPath).'@'.$prevRev. '&amp;compare[]='.urlencode($path).'@'.$rev;
-		$vars['comparelink'] = '<a href="'.$vars['compareurl'].'">'.$lang['DIFFPREV'].'</a>';
-	}
-
-	if (!$rep->hasReadAccess($path)) {
-		$vars['error'] = $lang['NOACCESS'];
-		sendHeaderForbidden();
-	}
-	$vars['restricted'] = !$rep->hasReadAccess($path, false);
-
-} else {
-	http_response_code(404);
 }
+
+$youngest = ($history && isset($history->entries[0])) ? $history->entries[0]->rev : 0;
+$vars['youngestrev'] = $youngest;
+
+// TODO The "youngest" rev is often incorrect when both path and rev are specified.
+// If a path was last modified at rev M and the URL contains rev N, it uses rev N.
+
+// Unless otherwise specified, we get the log details of the latest change
+$lastChangedRev = ($rev) ? $rev : $youngest;
+$history = $svnrep->getLog($path, $lastChangedRev, 1, false, 2, $peg, true);
+
+if (!$history) 
+{
+	http_response_code(404);
+	$vars['error'] = $lang['NOPATH'];
+}
+
+if (empty($rev))
+{
+	$rev = $lastChangedRev;
+}
+
+// Generate links to newer and older revisions
+$revurl = $config->getURL($rep, $path, 'revision');
+
+if ($rev < $youngest) 
+{
+	$vars['goyoungesturl'] = $config->getURL($rep, $path, 'revision');
+	$vars['goyoungestlink'] = '<a href="'.$vars['goyoungesturl'].'"'.($youngest ? ' title="'.$lang['REV'].' '.$youngest.'"' : '').'>'.$lang['GOYOUNGEST'].'</a>';
+
+	$history2 = $svnrep->getLog($path, $rev, $youngest, true, 2, $peg);
+	if (isset($history2->entries[1])) 
+	{
+		$nextRev = $history2->entries[1]->rev;
+		if ($nextRev != $youngest) 
+		{
+			$vars['nextrev'] = $nextRev;
+			$vars['nextrevurl'] = $revurl.createRevAndPegString($nextRev, $path != '/' ? $peg ? $peg : $rev : '');
+			//echo 'NEXT='.$vars['nextrevurl'].'<br/>';
+		}
+	}
+
+	unset($vars['error']);
+}
+
+if (isset($history->entries[1])) 
+{
+	$prevRev = $history->entries[1]->rev;
+	$prevPath = $history->entries[1]->path;
+	$vars['prevrev'] = $prevRev;
+	$vars['prevrevurl'] = $revurl.createRevAndPegString($prevRev, $path != '/' ? ($peg ? $peg : $rev) : '');
+	//echo 'PREV='.$vars['prevrevurl'].'<br/>';
+}
+
+// Save the entry from which we pull information for the current revision.
+$logEntry = (isset($history->entries[0])) ? $history->entries[0] : null;
+
+$bugtraq = new Bugtraq($rep, $svnrep, $ppath);
+
+$vars['action'] = '';
+$vars['rev'] = $rev;
+$vars['peg'] = $peg;
+$vars['path'] = escape($ppath);
+
+if ($logEntry) 
+{
+	$vars['date'] = $logEntry->date;
+	$vars['age'] = datetimeFormatDuration(time() - strtotime($logEntry->date));
+	$vars['author'] = $logEntry->author;
+	$vars['log'] = nl2br($bugtraq->replaceIDs(create_anchors(xml_entities($logEntry->msg))));
+}
+
+$isDir = @$_REQUEST['isdir'] == 1 || $path == '' || $path == '/';
+$vars['logurl'] = $config->getURL($rep, $path, 'log').$passRevString.($isDir ?  '&amp;isdir=1' : '');
+$vars['loglink'] = '<a href="'.$vars['logurl'].'">'.$lang['VIEWLOG'].'</a>';
+
+$dirPath = $isDir ? $path : dirname($path).'/';
+$vars['directoryurl'] = $config->getURL($rep, $dirPath, 'dir').$passRevString.'#'.anchorForPath($dirPath);
+$vars['directorylink'] = '<a href="'.$vars['directoryurl'].'">'.$lang['LISTING'].'</a>';
+
+if ($path != $dirPath) 
+{
+	$vars['filedetailurl'] = $config->getURL($rep, $path, 'file').$passRevString;
+	$vars['filedetaillink'] = '<a href="'.$vars['filedetailurl'].'">'.$lang['FILEDETAIL'].'</a>';
+	$vars['blameurl'] = $config->getURL($rep, $path, 'blame').$passRevString;
+	$vars['blamelink'] = '<a href="'.$vars['blameurl'].'">'.$lang['BLAME'].'</a>';
+}
+
+if ($rep->isRssEnabled()) 
+{
+	$vars['rssurl'] = $config->getURL($rep, $path, 'rss').createRevAndPegString('', $peg);
+	$vars['rsslink'] = '<a href="'.$vars['rssurl'].'">'.$lang['RSSFEED'].'</a>';
+}
+
+$changes = $logEntry ? $logEntry->mods : array();
+
+if (!is_array($changes)) 
+{
+	$changes = array();
+}
+
+usort($changes, 'SVNLogEntry_compare');
+
+$row = 0;
+
+$prevRevString = createRevAndPegString($rev - 1, $rev - 1);
+$thisRevString = createRevAndPegString($rev, $rev);
+
+foreach ($changes as $change) 
+{
+	$linkRevString = ($change->action == 'D') ? $prevRevString : $thisRevString;
+	$isDir = $change->isdir;
+
+	if ($isDir !== null) 
+	{
+		$isFile = !$isDir;
+	}
+	else 
+	{
+		// NOTE: This is a hack (runs `svn info` on each path) to see if it's a file.
+		// `svn log --verbose --xml` should really provide this info, but does only in recent version?
+		$lastSeenRev = ($change->action == 'D') ? $rev - 1 : $rev;
+		$isFile = $svnrep->isFile($change->path, $lastSeenRev, $lastSeenRev);
+	}
+
+	if (!$isFile && $change->path != '/') 
+	{
+		$change->path .= '/';
+	}
+
+	$resourceExisted = $change->action == 'M' || $change->copyfrom;
+	$listing[] = array(
+		'path' => escape($change->path),
+		'oldpath' => $change->copyfrom ? $change->copyfrom.' @ '.$change->copyrev : '',
+		'action' => $change->action,
+		'added' => $change->action == 'A',
+		'deleted' => $change->action == 'D',
+		'modified' => $change->action == 'M',
+		'detailurl' => $config->getURL($rep, $change->path, ($isFile ? 'file' : 'dir')).$linkRevString,
+		// For deleted resources, the log link points to the previous revision.
+		'logurl' => $config->getURL($rep, $change->path, 'log').$linkRevString.($isFile ? '' : '&amp;isdir=1'),
+		'diffurl' => $resourceExisted ? $config->getURL($rep, $change->path, 'diff').$linkRevString : '',
+		'blameurl' => $resourceExisted ? $config->getURL($rep, $change->path, 'blame').$linkRevString : '',
+		'rowparity' => $row,
+		'notinpath' => substr($change->path, 0, strlen($path)) != $path,
+	);
+
+	$row = 1 - $row;
+}
+
+if (isset($prevRev)) 
+{
+	$vars['compareurl'] = $config->getURL($rep, '', 'comp').'compare[]='.urlencode($prevPath).'@'.$prevRev. '&amp;compare[]='.urlencode($path).'@'.$rev;
+	$vars['comparelink'] = '<a href="'.$vars['compareurl'].'">'.$lang['DIFFPREV'].'</a>';
+}
+
+if (!$rep->hasReadAccess($path)) 
+{
+	$vars['error'] = $lang['NOACCESS'];
+	sendHeaderForbidden();
+}
+
+$vars['restricted'] = !$rep->hasReadAccess($path, false);
 
 renderTemplate('revision');

--- a/revision.php
+++ b/revision.php
@@ -31,7 +31,7 @@ require_once 'include/bugtraq.php';
 // Make sure that we have a repository
 if (!$rep)
 {
-	renderTemplate404('revision',$lang['NOREP']);
+	renderTemplate404('revision','NOREP');
 }
 
 $svnrep = new SVNRepository($rep);
@@ -50,7 +50,7 @@ if (!$history)
 
 	if (!$history) 
 	{
-		renderTemplate404('revision',$lang['NOPATH']);
+		renderTemplate404('revision','NOPATH');
 	}
 }
 
@@ -66,7 +66,7 @@ $history = $svnrep->getLog($path, $lastChangedRev, 1, false, 2, $peg, true);
 
 if (!$history) 
 {
-	renderTemplate404('revision',$lang['NOPATH']);
+	renderTemplate404('revision','NOPATH');
 }
 
 if (empty($rev))

--- a/revision.php
+++ b/revision.php
@@ -31,7 +31,7 @@ require_once 'include/bugtraq.php';
 // Make sure that we have a repository
 if (!$rep)
 {
-	renderTemplateNoRepo('revision');
+	renderTemplate404('revision',$lang['NOREP']);
 }
 
 $svnrep = new SVNRepository($rep);

--- a/revision.php
+++ b/revision.php
@@ -50,8 +50,7 @@ if (!$history)
 
 	if (!$history) 
 	{
-		http_response_code(404);
-		$vars['error'] = $lang['NOPATH'];
+		renderTemplate404('revision',$lang['NOPATH']);
 	}
 }
 
@@ -67,8 +66,7 @@ $history = $svnrep->getLog($path, $lastChangedRev, 1, false, 2, $peg, true);
 
 if (!$history) 
 {
-	http_response_code(404);
-	$vars['error'] = $lang['NOPATH'];
+	renderTemplate404('revision',$lang['NOPATH']);
 }
 
 if (empty($rev))

--- a/search.php
+++ b/search.php
@@ -208,7 +208,7 @@ function showSearchResults($svnrep, $path, $searchstring, $rev, $peg, $listing, 
 // Make sure that we have a repository
 if (!$rep)
 {
-	renderTemplateNoRepo('directory');
+	renderTemplate404('directory',$lang['NOREP']);
 }
 
 $svnrep = new SVNRepository($rep);

--- a/search.php
+++ b/search.php
@@ -208,7 +208,7 @@ function showSearchResults($svnrep, $path, $searchstring, $rev, $peg, $listing, 
 // Make sure that we have a repository
 if (!$rep)
 {
-	renderTemplate404('directory',$lang['NOREP']);
+	renderTemplate404('directory','NOREP');
 }
 
 $svnrep = new SVNRepository($rep);
@@ -232,7 +232,7 @@ if (!$history)
 	$history = $svnrep->getLog($path, '', '', false, 2, ($path == '/') ? '' : $peg);
 	if (!$history)
 	{
-		renderTemplate404('directory',$lang['NOPATH']);
+		renderTemplate404('directory','NOPATH');
 	}
 }
 

--- a/search.php
+++ b/search.php
@@ -232,8 +232,7 @@ if (!$history)
 	$history = $svnrep->getLog($path, '', '', false, 2, ($path == '/') ? '' : $peg);
 	if (!$history)
 	{
-		http_response_code(404);
-		$vars['error'] = $lang['NOPATH'];
+		renderTemplate404('directory',$lang['NOPATH']);
 	}
 }
 

--- a/templates/Elegant/directory.tmpl
+++ b/templates/Elegant/directory.tmpl
@@ -1,5 +1,5 @@
     [websvn-test:error]
-    <div id="error">[websvn:error]</div>
+    </div>
     [websvn-else]
       <h2 id="pathlinks">[websvn:pathlinks]</h2>
       <div id="revjump">[websvn:revision_form][websvn:revision_input]<span class="submit">[websvn:revision_submit]</span>[websvn:revision_endform]</div>

--- a/templates/Elegant/directory.tmpl
+++ b/templates/Elegant/directory.tmpl
@@ -1,5 +1,5 @@
     [websvn-test:error]
-    </div>
+    <div id="error">[websvn:error]</div>
     [websvn-else]
       <h2 id="pathlinks">[websvn:pathlinks]</h2>
       <div id="revjump">[websvn:revision_form][websvn:revision_input]<span class="submit">[websvn:revision_submit]</span>[websvn:revision_endform]</div>


### PR DESCRIPTION
As i had some extra time. I took it upon my self to do following changes with this PR.
1 - Implemented the exit first scenario wherever applicable and tried to bring everything as discuss in the coding guidelines. 
(Probably we should make a small wiki page with a coding guidelines)
2 - Showed how the error tag in the templates can be used for showing the 404 error. 

If we can decide upon a 404 error message we can provide support for multiple languages like `lang['404']` instead of a static text here:
![image](https://user-images.githubusercontent.com/4973182/95024076-802d8b80-069e-11eb-95da-50a564e349bb.png)

Further improvements that are seen though not neccessary is that:
1 - There are 34 instances in the entire websvn where http_response_code is called with an error number (404|403|500)
We can take this opportunity to iumprove scenarios as:
![image](https://user-images.githubusercontent.com/4973182/95024030-26c55c80-069e-11eb-9648-23b4cf46629e.png)

2 - Basically this would mean extending the `renderTemplateNoRepo` to something more to add these error messages. Like additional arguments.

Let me know your thoughts.