### PR TITLE
Fix path display in log.php when showChanges is disabled

### DIFF
--- a/log.php
+++ b/log.php
@@ -299,7 +299,7 @@ if (!empty($history))
 
 	if ($brev && $erev) 
 	{
-		$history = $svnrep->getLog($path, $brev, $erev, false, 0, $peg, $showchanges);
+		$history = $svnrep->getLog($path, $brev, $erev, false, 0, $peg, true);
 		if ($history)
 		{
 			$entries = $history->entries;


### PR DESCRIPTION
Without `$config->setLogsShowChanges(true);`, the paths on log.php don't get set, due to the svn command getting run without the verbose flag, meaning that the paths never get output.

Before:

![image](https://user-images.githubusercontent.com/4007992/96161603-65b1a880-0f0f-11eb-9fac-ce20125701db.png)

After:


![image](https://user-images.githubusercontent.com/4007992/96161796-a6112680-0f0f-11eb-88b2-46c21faecbc8.png)
