### PR TITLE
Make the root-phrase of the breadcrumb path configurable.

### DIFF
--- a/include/configclass.php
+++ b/include/configclass.php
@@ -691,7 +691,7 @@ class WebSvnConfig {
 	var $quote = "'";
 	var $pathSeparator = ':';
 	var $fileUrlPrefix = 'file://';
-	var $nameBreadcrumbRepoRootAsRepo = false;
+	var $breadcrumbRepoRootAsRepo = false;
 
 	var $_repositories = array();
 
@@ -1683,12 +1683,12 @@ class WebSvnConfig {
 
 	// {{{ Change the name of the breadcrumb root-phrase to that of the current repo?
 
-	function nameBreadcrumbRepoRootAsRepo() {
-		$this->nameBreadcrumbRepoRootAsRepo = true;
+	function setBreadcrumbRepoRootAsRepo($newValue) {
+		$this->breadcrumbRepoRootAsRepo = $newValue;
 	}
 
-	function getNameBreadcrumbRepoRootAsRepo() {
-		return $this->nameBreadcrumbRepoRootAsRepo;
+	function getBreadcrumbRepoRootAsRepo() {
+		return $this->breadcrumbRepoRootAsRepo;
 	}
 
 	// }}}

--- a/include/configclass.php
+++ b/include/configclass.php
@@ -691,6 +691,7 @@ class WebSvnConfig {
 	var $quote = "'";
 	var $pathSeparator = ':';
 	var $fileUrlPrefix = 'file://';
+	var $nameBreadcrumbRepoRootAsRepo = false;
 
 	var $_repositories = array();
 
@@ -1676,6 +1677,18 @@ class WebSvnConfig {
 		if (!empty($this->_repositories)) {
 			mergesort($this->_repositories, 'cmpGroups');
 		}
+	}
+
+	// }}}
+
+	// {{{ Change the name of the breadcrumb root-phrase to that of the current repo?
+
+	function nameBreadcrumbRepoRootAsRepo() {
+		$this->nameBreadcrumbRepoRootAsRepo = true;
+	}
+
+	function getNameBreadcrumbRepoRootAsRepo() {
+		return $this->nameBreadcrumbRepoRootAsRepo;
 	}
 
 	// }}}

--- a/include/distconfig.php
+++ b/include/distconfig.php
@@ -520,6 +520,6 @@ $config->expandTabsBy(8);
 // $config->expandTabsBy(3, 'myrep'); // Expand Tabs by 3 for repository 'myrep'
 
 // Change the name of the breadcrumb root-phrase to that of the current repo?
-// $config->nameBreadcrumbRepoRootAsRepo();
+// $config->setBreadcrumbRepoRootAsRepo(true);
 
 // }}}

--- a/include/distconfig.php
+++ b/include/distconfig.php
@@ -169,11 +169,11 @@ $config->addTemplatePath($locwebsvnreal.'/templates/Elegant/');
 // By default, WebSVN loads parent path directories and then on user click other,
 // This options loads the entire directory in one go and allows to browse without delay.
 // By default all will be collapsed to root directory and can be expanded.
-// The performance will be impacted as it takes time to load up all the things in the 
+// The performance will be impacted as it takes time to load up all the things in the
 // repository. Once loaded directory exapansion is instantaneous.
-// The alphabetical order is applied to all directory and files. 
+// The alphabetical order is applied to all directory and files.
 // This means that grouping of all dirs together and all files together is NOT supported currently!
-// The files and directories are shown as is with a mixture of files and folders. 
+// The files and directories are shown as is with a mixture of files and folders.
 
 // $config->setLoadAllRepos(true);
 
@@ -412,10 +412,10 @@ $config->setMinDownloadLevel(2);
 
 // {{{ Markdown Render
 
-// Uncomment this line if you want to enable Markdown Rendering of README.md file in the path. 
+// Uncomment this line if you want to enable Markdown Rendering of README.md file in the path.
 // You will need the Parsedown.php (https://github.com/erusev/parsedown) library for this to work.
 // This will look for README.md file on the path and render it.
-// The name of "README.md" isn't configurable for now to simply follow GitHub's conventions. 
+// The name of "README.md" isn't configurable for now to simply follow GitHub's conventions.
 
 // $config->useParsedown();
 
@@ -518,5 +518,8 @@ $config->expandTabsBy(8);
 // Use the convention 'groupname.myrep' if your repository is in a group.
 
 // $config->expandTabsBy(3, 'myrep'); // Expand Tabs by 3 for repository 'myrep'
+
+// Change the name of the breadcrumb root-phrase to that of the current repo?
+// $config->nameBreadcrumbRepoRootAsRepo();
 
 // }}}

--- a/include/utils.php
+++ b/include/utils.php
@@ -52,7 +52,7 @@ function createPathLinks($rep, $path, $rev, $peg = '') {
 	$vars['path_links']				= '';
 	$vars['path_links_root_root']	= "<a href=\"${pathSoFarURL}\" class=\"root\"><span>${rootName}</span></a>";
 	$vars['path_links_root_repo']	= "<a href=\"${pathSoFarURL}\" class=\"root\"><span>${repoName}</span></a>";
-	$vars['path_links_root_config']	= $config->getNameBreadcrumbRepoRootAsRepo()
+	$vars['path_links_root_config']	= $config->getBreadcrumbRepoRootAsRepo()
 										? $vars['path_links_root_repo']
 										: $vars['path_links_root_root'];
 

--- a/include/utils.php
+++ b/include/utils.php
@@ -27,7 +27,7 @@
 // Create a list of links to the current path that'll be available from the template
 
 function createPathLinks($rep, $path, $rev, $peg = '') {
-	global $vars, $config;
+	global $config, $lang, $vars;
 
 	$pathComponents = explode('/', escape($path));
 	$count = count($pathComponents);
@@ -42,24 +42,32 @@ function createPathLinks($rep, $path, $rev, $peg = '') {
 		$dir = false;
 	}
 
-	$passRevString = createRevAndPegString($rev, $peg);
+	$passRevString	= createRevAndPegString($rev, $peg);
+	$pathSoFar		= '/';
+	$pathSoFarURL	= $config->getURL($rep, $pathSoFar, 'dir').$passRevString;
 
-	$pathSoFar = '/';
-	$pathSoFarURL = $config->getURL($rep, $pathSoFar, 'dir').$passRevString;
-	$vars['pathlinks'] = '<a href="'.$pathSoFarURL.'" class="root"><span>(root)</span></a>/';
+	$repoName = $rep->getDisplayName();
+	$rootName = $lang['BREADCRUMB_REPO_ROOT'];
+
+	$vars['path_links']				= '';
+	$vars['path_links_root_root']	= "<a href=\"${pathSoFarURL}\" class=\"root\"><span>${rootName}</span></a>";
+	$vars['path_links_root_repo']	= "<a href=\"${pathSoFarURL}\" class=\"root\"><span>${repoName}</span></a>";
+	$vars['path_links_root_config']	= $config->getNameBreadcrumbRepoRootAsRepo()
+										? $vars['path_links_root_repo']
+										: $vars['path_links_root_root'];
 
 	for ($n = 1; $n < $limit; $n++) {
 		$pathSoFar .= html_entity_decode($pathComponents[$n]).'/';
 		$pathSoFarURL = $config->getURL($rep, $pathSoFar, 'dir').$passRevString;
-		$vars['pathlinks'] .= '<a href="'.$pathSoFarURL.'#'.anchorForPath($pathSoFar).'">'.$pathComponents[$n].'</a>/';
+		$vars['path_links'] .= '<a href="'.$pathSoFarURL.'#'.anchorForPath($pathSoFar).'">'.$pathComponents[$n].'</a>/';
 	}
 
 	if (!empty($pathComponents[$n])) {
 		$pegrev = ($peg && $peg != $rev) ? ' <a class="peg" href="'.'?'.escape(str_replace('&peg='.$peg, '', $_SERVER['QUERY_STRING'])).'">@ '.$peg.'</a>' : '';
 		if ($dir) {
-			$vars['pathlinks'] .= '<span class="dir">'.$pathComponents[$n].'/'.$pegrev.'</span>';
+			$vars['path_links'] .= '<span class="dir">'.$pathComponents[$n].'/'.$pegrev.'</span>';
 		} else {
-			$vars['pathlinks'] .= '<span class="file">'.$pathComponents[$n].$pegrev.'</span>';
+			$vars['path_links'] .= '<span class="file">'.$pathComponents[$n].$pegrev.'</span>';
 		}
 	}
 }

--- a/languages/catalan.php
+++ b/languages/catalan.php
@@ -28,6 +28,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Catalan";
 $lang["LANGUAGENAMENATIVE"] = "Català-Valencià";
 $lang["LANGUAGENAMEHTML"] = "Catal&agrave;-Valenci&agrave;";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "Registre";
 $lang["DIFF"] = "Diferència";
 

--- a/languages/chinese-simplified.php
+++ b/languages/chinese-simplified.php
@@ -30,6 +30,7 @@ $lang["LANGUAGENAMEENGLISH"] = "Simplified Chinese";
 $lang["LANGUAGENAMENATIVE"] = "中文";
 $lang["LANGUAGENAMEHTML"] = "&#20013;&#25991;";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
 
 $lang["LOG"] = "记录";
 $lang["DIFF"] = "差异";

--- a/languages/chinese-traditional.php
+++ b/languages/chinese-traditional.php
@@ -30,6 +30,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Traditional Chinese";
 $lang["LANGUAGENAMENATIVE"] = "中文";
 $lang["LANGUAGENAMEHTML"] = "&#20013;&#25991;";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "歷史記錄";
 $lang["DIFF"] = "比對";
 

--- a/languages/czech.php
+++ b/languages/czech.php
@@ -28,6 +28,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Czech";
 $lang["LANGUAGENAMENATIVE"] = "Česky";
 $lang["LANGUAGENAMEHTML"] = "&#268;esky";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "Záznam";
 // $lang["DIFF"] = "Diff";
 

--- a/languages/danish.php
+++ b/languages/danish.php
@@ -29,6 +29,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Danish";
 $lang["LANGUAGENAMENATIVE"] = "Dansk";
 $lang["LANGUAGENAMEHTML"] = "Dansk";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 // $lang["LOG"] = "Log";
 $lang["DIFF"] = "Sammenlign";
 

--- a/languages/dutch.php
+++ b/languages/dutch.php
@@ -31,6 +31,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Dutch";
 $lang["LANGUAGENAMENATIVE"] = "Nederlands";
 $lang["LANGUAGENAMEHTML"] = "Nederlands";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "Log";
 $lang["DIFF"] = "Diff";
 

--- a/languages/english.php
+++ b/languages/english.php
@@ -28,6 +28,8 @@ $lang["LANGUAGENAMEENGLISH"] = "English";
 $lang["LANGUAGENAMENATIVE"] = "English";
 $lang["LANGUAGENAMEHTML"] = "English";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "Log";
 $lang["DIFF"] = "Diff";
 

--- a/languages/finnish.php
+++ b/languages/finnish.php
@@ -29,6 +29,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Finnish";
 $lang["LANGUAGENAMENATIVE"] = "Suomi";
 $lang["LANGUAGENAMEHTML"] = "Suomi";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "Loki";
 $lang["DIFF"] = "Diff";
 

--- a/languages/french.php
+++ b/languages/french.php
@@ -29,6 +29,8 @@ $lang["LANGUAGENAMEENGLISH"] = "French";
 $lang["LANGUAGENAMENATIVE"] = "Français";
 $lang["LANGUAGENAMEHTML"] = "Fran&ccedil;ais";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "Journal";
 $lang["DIFF"] = "Diffé.";
 

--- a/languages/german.php
+++ b/languages/german.php
@@ -28,6 +28,8 @@ $lang["LANGUAGENAMEENGLISH"] = "German";
 $lang["LANGUAGENAMENATIVE"] = "Deutsch";
 $lang["LANGUAGENAMEHTML"] = "Deutsch";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "Log";
 $lang["DIFF"] = "Diff";
 

--- a/languages/hebrew.php
+++ b/languages/hebrew.php
@@ -28,6 +28,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Hebrew";
 $lang["LANGUAGENAMENATIVE"] = "עברית";
 $lang["LANGUAGENAMEHTML"] = "&#1506;&#1489;&#1512;&#1497;&#1514;";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "לוג";
 $lang["DIFF"] = "שוני";
 

--- a/languages/hindi.php
+++ b/languages/hindi.php
@@ -31,6 +31,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Hindi";
 $lang["LANGUAGENAMENATIVE"] = "हिंदी";
 $lang["LANGUAGENAMEHTML"] = "&#2361;&#2367;&#2306;&#2342;&#2368;";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "टिप्पणी";
 $lang["DIFF"] = "फ़र्क";
 

--- a/languages/hungarian.php
+++ b/languages/hungarian.php
@@ -28,6 +28,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Hungarian";
 $lang["LANGUAGENAMENATIVE"] = "Magyar";
 $lang["LANGUAGENAMEHTML"] = "Magyar";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "Napló";
 $lang["DIFF"] = "Diff";
 

--- a/languages/indonesian.php
+++ b/languages/indonesian.php
@@ -29,6 +29,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Indonesian";
 $lang["LANGUAGENAMENATIVE"] = "Bahasa Indonesia";
 $lang["LANGUAGENAMEHTML"] = "Bahasa Indonesia";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "Log";
 $lang["DIFF"] = "Perbedaan";
 

--- a/languages/italian.php
+++ b/languages/italian.php
@@ -29,6 +29,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Italian";
 $lang["LANGUAGENAMENATIVE"] = "Italiano";
 $lang["LANGUAGENAMEHTML"] = "Italiano";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "Log";
 $lang["DIFF"] = "Diff";
 

--- a/languages/japanese.php
+++ b/languages/japanese.php
@@ -29,6 +29,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Japanese";
 $lang["LANGUAGENAMENATIVE"] = "日本語";
 $lang["LANGUAGENAMEHTML"] = "&#26085;&#26412;&#35486;";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "ログ";
 $lang["DIFF"] = "差分";
 

--- a/languages/korean.php
+++ b/languages/korean.php
@@ -29,6 +29,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Korean";
 $lang["LANGUAGENAMENATIVE"] = "한국어";
 $lang["LANGUAGENAMEHTML"] = "&#54620;&#44397;&#50612;";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "로그";
 $lang["DIFF"] = "비교";
 

--- a/languages/macedonian.php
+++ b/languages/macedonian.php
@@ -29,6 +29,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Macedonian";
 $lang["LANGUAGENAMENATIVE"] = "Македонски";
 $lang["LANGUAGENAMEHTML"] = "&#1052;&#1072;&#1082;&#1077;&#1076;&#1086;&#1085;&#1089;&#1082;&#1080;";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "Забелешка";
 $lang["DIFF"] = "Разлика";
 

--- a/languages/marathi.php
+++ b/languages/marathi.php
@@ -31,6 +31,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Marathi";
 $lang["LANGUAGENAMENATIVE"] = "मराठी";
 $lang["LANGUAGENAMEHTML"] = "&#2350;&#2352;&#2366;&#2336;&#2368;";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "शेरा";
 $lang["DIFF"] = "फरक";
 

--- a/languages/norwegian.php
+++ b/languages/norwegian.php
@@ -34,6 +34,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Norwegian";
 $lang["LANGUAGENAMENATIVE"] = "Norsk";
 $lang["LANGUAGENAMEHTML"] = "Norsk";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "Logg";
 $lang["DIFF"] = "Diff";
 

--- a/languages/polish.php
+++ b/languages/polish.php
@@ -28,6 +28,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Polish";
 $lang["LANGUAGENAMENATIVE"] = "Polski";
 $lang["LANGUAGENAMEHTML"] = "Polski";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "Dziennik zmian";
 $lang["DIFF"] = "Różnice";
 

--- a/languages/portuguese-br.php
+++ b/languages/portuguese-br.php
@@ -29,6 +29,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Portuguese (Brazil)";
 $lang["LANGUAGENAMENATIVE"] = "Português";
 $lang["LANGUAGENAMEHTML"] = "Portugu&ecirc;s";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "Log";
 $lang["DIFF"] = "Diferenças";
 

--- a/languages/portuguese.php
+++ b/languages/portuguese.php
@@ -28,6 +28,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Portuguese";
 $lang["LANGUAGENAMENATIVE"] = "Português";
 $lang["LANGUAGENAMEHTML"] = "Portugu&ecirc;s";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "Log";
 $lang["DIFF"] = "Diferenças";
 

--- a/languages/russian.php
+++ b/languages/russian.php
@@ -29,6 +29,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Russian";
 $lang["LANGUAGENAMENATIVE"] = "Русский";
 $lang["LANGUAGENAMEHTML"] = "&#1056;&#1091;&#1089;&#1089;&#1082;&#1080;&#1081;";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "Журнал";
 $lang["DIFF"] = "Различия";
 

--- a/languages/slovak.php
+++ b/languages/slovak.php
@@ -28,6 +28,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Slovak";
 $lang["LANGUAGENAMENATIVE"] = "Slovenčina";
 $lang["LANGUAGENAMEHTML"] = "Sloven&#269;ina";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "Denník";
 $lang["DIFF"] = "Diff";
 

--- a/languages/slovenian.php
+++ b/languages/slovenian.php
@@ -29,6 +29,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Slovenian";
 $lang["LANGUAGENAMENATIVE"] = "Slovenščina";
 $lang["LANGUAGENAMEHTML"] = "Sloven&#353;&#269;ina";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "Dnevnik";
 $lang["DIFF"] = "Razlike";
 

--- a/languages/spanish.php
+++ b/languages/spanish.php
@@ -28,6 +28,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Spanish";
 $lang["LANGUAGENAMENATIVE"] = "Español";
 $lang["LANGUAGENAMEHTML"] = "Espa&ntilde;ol";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "Log";
 $lang["DIFF"] = "Diff";
 

--- a/languages/swedish.php
+++ b/languages/swedish.php
@@ -28,6 +28,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Swedish";
 $lang["LANGUAGENAMENATIVE"] = "Svenska";
 $lang["LANGUAGENAMEHTML"] = "Svenska";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "Logg";
 $lang["DIFF"] = "Skillnad";
 

--- a/languages/turkish.php
+++ b/languages/turkish.php
@@ -29,6 +29,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Turkish";
 $lang["LANGUAGENAMENATIVE"] = "Türkçe";
 $lang["LANGUAGENAMEHTML"] = "T&uuml;rk&ccedil;e";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "Kayıt";
 $lang["DIFF"] = "Fark";
 

--- a/languages/ukrainian.php
+++ b/languages/ukrainian.php
@@ -21,7 +21,7 @@
 //
 // ukrainian.php
 //
-// Ukrainian language strings (UTF-8 encoding) 
+// Ukrainian language strings (UTF-8 encoding)
 // by Vitaliy Tsybulyak <fauve@ukr.net>
 
 $lang["LANGUAGETAG"] = "uk"; // Language tag (RFC 4646) for this translation.
@@ -29,30 +29,32 @@ $lang["LANGUAGENAMEENGLISH"] = "Ukrainian";
 $lang["LANGUAGENAMENATIVE"] = "Українська";
 $lang["LANGUAGENAMEHTML"] = "&#1059;&#1082;&#1088;&#1072;&#1111;&#1085;&#1089;&#1100;&#1082;&#1072;";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "Журнал";
 $lang["DIFF"] = "Відмінності";
 
-$lang["NOREP"] = "Репозитарію не вказано";  
-$lang["NOPATH"] = "Шлях не знайдено";   
-$lang["NOACCESS"] = "У вас недостатньо дозволів на читання цього каталогу"; 
+$lang["NOREP"] = "Репозитарію не вказано";
+$lang["NOPATH"] = "Шлях не знайдено";
+$lang["NOACCESS"] = "У вас недостатньо дозволів на читання цього каталогу";
 $lang["RESTRICTED"] = "Обмежений доступ";
 $lang["SUPPLYREP"] = "Задайте будь ласка шлях до репозитарію в include/config.php за допомогою <code>\$config->parentPath</code> або <code>\$config->addRepository</code>. Додатковий опис можна знайти в довіднику зі встановлення.";
 
 $lang["DIFFREVS"] = "Відмінності між редагуваннями";
-$lang["AND"] = "і";     
-$lang["REV"] = "Версія";    
-$lang["LINE"] = "Рядок";    
-$lang["LINENO"] = "№ рядка"; 
-$lang["SHOWENTIREFILE"] = "Показати увесь файл";                
-$lang["SHOWCOMPACT"] = "Показати тільки ділянки з відмінностями"; 
+$lang["AND"] = "і";
+$lang["REV"] = "Версія";
+$lang["LINE"] = "Рядок";
+$lang["LINENO"] = "№ рядка";
+$lang["SHOWENTIREFILE"] = "Показати увесь файл";
+$lang["SHOWCOMPACT"] = "Показати тільки ділянки з відмінностями";
 $lang["IGNOREWHITESPACE"] = "Ігнорувати пробіли";
 $lang["REGARDWHITESPACE"] = "Зважати на пробіли";
 
 $lang["LISTING"] = "Вивід вмісту каталогу";
-$lang["FILEDETAIL"] = "Докладніше"; 
+$lang["FILEDETAIL"] = "Докладніше";
 $lang["VIEWAS"] = "Показати як";
-$lang["DIFFPREV"] = "Порівняти з попередньою"; 
-$lang["BLAME"] = "Авторство"; 
+$lang["DIFFPREV"] = "Порівняти з попередньою";
+$lang["BLAME"] = "Авторство";
 $lang["BLAMEFOR"] = "Інформація про авторство версії";
 
 $lang["REVINFO"] = "Інформація про версію";

--- a/languages/uzbek.php
+++ b/languages/uzbek.php
@@ -29,6 +29,8 @@ $lang["LANGUAGENAMEENGLISH"] = "Uzbek";
 $lang["LANGUAGENAMENATIVE"] = "Oëzbekcha";
 $lang["LANGUAGENAMEHTML"] = "O&euml;zbekcha";
 
+$lang['BREADCRUMB_REPO_ROOT'] = '(root)';
+
 $lang["LOG"] = "Log";
 $lang["DIFF"] = "Farq";
 

--- a/templates/BlueGrey/blame.tmpl
+++ b/templates/BlueGrey/blame.tmpl
@@ -4,7 +4,7 @@
     <div id="error">[websvn:error]</div>
 [websvn-else]
     <div id="revjump">[websvn:revision_form]<b>[lang:REV]:</b>[websvn:revision_input][websvn:revision_submit][websvn:revision_endform]</div>
-    <div id="pathlinks">[websvn:pathlinks]</div>
+    <div id="path_links">[websvn:path_links_root_config]/[websvn:path_links]</div>
     <div id="nav">
       [websvn-test:prevrevurl]
       <a href="[websvn:prevrevurl]">[lang:REV] [websvn:prevrev]</a> &ndash;
@@ -56,7 +56,7 @@
       </tr>
       [websvn-endlisting]
       </tbody>
-    </table> 
+    </table>
     [websvn:javascript]
   [websvn-endtest]
 [websvn-endtest]

--- a/templates/BlueGrey/diff.tmpl
+++ b/templates/BlueGrey/diff.tmpl
@@ -8,7 +8,7 @@
     <div id="error">[websvn:error]</div>
 [websvn-else]
     <div id="revjump">[websvn:revision_form]<b>[lang:REV]:</b>[websvn:revision_input][websvn:revision_submit][websvn:revision_endform]</div>
-    <div id="pathlinks">[websvn:pathlinks]</div>
+    <div id="path_links">[websvn:path_links_root_config]/[websvn:path_links]</div>
     <div id="nav">
       [websvn-test:prevrevurl]
       <a href="[websvn:prevrevurl]">[lang:REV] [websvn:prevrev]</a> &ndash;

--- a/templates/BlueGrey/directory.tmpl
+++ b/templates/BlueGrey/directory.tmpl
@@ -7,7 +7,7 @@
     [websvn-test:search]
     <div id="searchcss">[websvn:search_form]<div>[lang:SEARCH] [websvn:search_input]<span class="submit">[websvn:search_submit]</span></div>[websvn:search_endform]</div>
     [websvn-endtest]
-    <div id="pathlinks">[websvn:pathlinks]</div>
+    <div id="path_links">[websvn:path_links_root_config]/[websvn:path_links]</div>
     [websvn-test:warning]
     [websvn-else]
     <table cellpadding="2" cellspacing="0" class="outline">
@@ -90,7 +90,7 @@ e-node=<img class="icon" border="0" width="24" height="22" src="[websvn:locwebsv
         </thead>
         <tbody>
       [websvn-startlisting]
-        <tr class="row[websvn:rowparity]" 
+        <tr class="row[websvn:rowparity]"
           [websvn-test:loadalldir]
             title="[websvn:classname]"
           [websvn-endtest]

--- a/templates/BlueGrey/file.tmpl
+++ b/templates/BlueGrey/file.tmpl
@@ -4,7 +4,7 @@
     <div id="error">[websvn:error]</div>
 [websvn-else]
     <div id="revjump">[websvn:revision_form]<b>[lang:REV]:</b>[websvn:revision_input][websvn:revision_submit][websvn:revision_endform]</div>
-    <div id="pathlinks">[websvn:pathlinks]</div>
+    <div id="path_links">[websvn:path_links_root_config]/[websvn:path_links]</div>
     <div id="nav">
       [websvn-test:prevrevurl]
       <a href="[websvn:prevrevurl]">[lang:REV] [websvn:prevrev]</a> &ndash;

--- a/templates/BlueGrey/log.tmpl
+++ b/templates/BlueGrey/log.tmpl
@@ -4,7 +4,7 @@
     <div id="error">[websvn:error]</div>
 [websvn-else]
     <div id="revjump">[websvn:revision_form]<b>[lang:REV]:</b>[websvn:revision_input][websvn:revision_submit][websvn:revision_endform]</div>
-    <div id="pathlinks">[websvn:pathlinks]</div>
+    <div id="path_links">[websvn:path_links_root_config]/[websvn:path_links]</div>
     <div id="nav">
       [websvn-test:goyoungestlink]
       [websvn:goyoungestlink] &ndash;

--- a/templates/BlueGrey/revision.tmpl
+++ b/templates/BlueGrey/revision.tmpl
@@ -4,7 +4,7 @@
     <div id="error">[websvn:error]</div>
 [websvn-else]
     <div id="revjump">[websvn:revision_form]<b>[lang:REV]:</b>[websvn:revision_input][websvn:revision_submit][websvn:revision_endform]</div>
-    <div id="pathlinks">[websvn:pathlinks]</div>
+    <div id="path_links">[websvn:path_links_root_config]/[websvn:path_links]</div>
     [websvn-test:warning]
     [websvn-else]
     <table cellpadding="2" cellspacing="0" class="outline">

--- a/templates/BlueGrey/styles.css
+++ b/templates/BlueGrey/styles.css
@@ -63,7 +63,7 @@ code {
 	clear: both;
 }
 
-#pathlinks {
+#path_links {
 	clear: left;
 	padding-top: 5px;
 }

--- a/templates/Elegant/blame.tmpl
+++ b/templates/Elegant/blame.tmpl
@@ -1,7 +1,7 @@
     [websvn-test:error]
     </div>
     [websvn-else]
-      <h2 id="pathlinks">[websvn:pathlinks]</h2>
+      <h2 id="path_links">[websvn:path_links_root_config]/[websvn:path_links]</h2>
       <div id="revjump">[websvn:revision_form][websvn:revision_input]<span class="submit">[websvn:revision_submit]</span>[websvn:revision_endform]</div>
       <h2 id="revnum"><a href="[websvn:revurl]">[lang:REV] [websvn:rev]</a></h2>
       <div class="clearer"></div>

--- a/templates/Elegant/diff.tmpl
+++ b/templates/Elegant/diff.tmpl
@@ -1,7 +1,7 @@
     [websvn-test:error]
     </div>
     [websvn-else]
-      <h2 id="pathlinks">[websvn:pathlinks]</h2>
+      <h2 id="path_links">[websvn:path_links_root_config]/[websvn:path_links]</h2>
       <div id="revjump">[websvn:revision_form][websvn:revision_input]<span class="submit">[websvn:revision_submit]</span>[websvn:revision_endform]</div>
       [websvn-test:noprev]
       <h2 id="revnum"><a href="[websvn:revurl]">[lang:REV] [websvn:rev1]</a></h2>

--- a/templates/Elegant/directory.tmpl
+++ b/templates/Elegant/directory.tmpl
@@ -1,7 +1,7 @@
     [websvn-test:error]
     </div>
     [websvn-else]
-      <h2 id="pathlinks">[websvn:pathlinks]</h2>
+      <h2 id="path_links">[websvn:path_links_root_config]/[websvn:path_links]</h2>
       <div id="revjump">[websvn:revision_form][websvn:revision_input]<span class="submit">[websvn:revision_submit]</span>[websvn:revision_endform]</div>
       [websvn-test:search]
       <div id="searchcss">[websvn:search_form]<div>[lang:SEARCH] [websvn:search_input]<span class="submit">[websvn:search_submit]</span></div>[websvn:search_endform]</div>
@@ -94,7 +94,7 @@ e-node=<img src="[websvn:locwebsvnhttp]/templates/Elegant/images/blank.png" alt=
         <tbody>
         [websvn-startlisting]
           [websvn-test:rowparity]
-          <tr class="shaded" 
+          <tr class="shaded"
           [websvn-test:loadalldir]
               title="[websvn:classname]"
           [websvn-endtest]

--- a/templates/Elegant/file.tmpl
+++ b/templates/Elegant/file.tmpl
@@ -1,7 +1,7 @@
     [websvn-test:error]
     </div>
     [websvn-else]
-      <h2 id="pathlinks">[websvn:pathlinks]</h2>
+      <h2 id="path_links">[websvn:path_links_root_config]/[websvn:path_links]</h2>
       <div id="revjump">[websvn:revision_form][websvn:revision_input]<span class="submit">[websvn:revision_submit]</span>[websvn:revision_endform]</div>
       <h2 id="revnum"><a href="[websvn:revurl]">[lang:REV] [websvn:rev]</a></h2>
       <div class="clearer"></div>

--- a/templates/Elegant/log.tmpl
+++ b/templates/Elegant/log.tmpl
@@ -1,7 +1,7 @@
     [websvn-test:error]
     </div>
     [websvn-else]
-      <h2 id="pathlinks">[websvn:pathlinks]</h2>
+      <h2 id="path_links">[websvn:path_links_root_config]/[websvn:path_links]</h2>
       <div id="revjump">[websvn:revision_form][websvn:revision_input]<span class="submit">[websvn:revision_submit]</span>[websvn:revision_endform]</div>
       <h2 id="revnum"><a href="[websvn:revurl]">[lang:REV] [websvn:rev]</a></h2>
       <div class="clearer"></div>
@@ -62,7 +62,7 @@
     [websvn-test:logsearch_nomorematches]
       <p>[lang:NOMORERESULTS]</p>
     [websvn-endtest]
-    
+
     [websvn-test:logsearch_resultsfound]
     [websvn:compare_form]
     <table id="logs">
@@ -118,7 +118,7 @@
       [websvn-endlisting]
       </tbody>
     </table>
-    <div id="comparesubmit">[websvn:compare_submit]</div>  
+    <div id="comparesubmit">[websvn:compare_submit]</div>
     [websvn:compare_endform]
     [websvn-endtest]
     [websvn-endtest]

--- a/templates/Elegant/revision.tmpl
+++ b/templates/Elegant/revision.tmpl
@@ -1,7 +1,7 @@
     [websvn-test:error]
     </div>
     [websvn-else]
-      <h2 id="pathlinks">[websvn:pathlinks]</h2>
+      <h2 id="path_links">[websvn:path_links_root_config]/[websvn:path_links]</h2>
       <div id="revjump">[websvn:revision_form][websvn:revision_input]<span class="submit">[websvn:revision_submit]</span>[websvn:revision_endform]</div>
       <h2 id="revnum">[lang:REV] [websvn:rev]</h2>
       <div class="clearer"></div>

--- a/templates/Elegant/styles.css
+++ b/templates/Elegant/styles.css
@@ -100,7 +100,7 @@ form {
 	padding: 0 2px;
 }
 
-#header #info a:hover, #header #info h2#pathlinks a:hover {
+#header #info a:hover, #header #info h2#path_links a:hover {
 	background-color: rgba(63,63,63,0.35);
 }
 
@@ -179,20 +179,20 @@ form {
 	clear: both;
 }
 
-#header h2#pathlinks > * {
+#header h2#path_links > * {
 	padding: 1px;
 }
 
-#header h2#pathlinks a.root {
+#header h2#path_links a.root {
 	background: url(images/home.png) no-repeat 0 1px;
 	padding-left: 16px;
 }
 
-#header h2#pathlinks a.root span {
+#header h2#path_links a.root span {
 	display: none;
 }
 
-#header h2#pathlinks a.peg {
+#header h2#path_links a.peg {
 	background: url(images/remove.png) no-repeat right 1px;
 	padding-right: 20px;
 }

--- a/templates/calm/blame.tmpl
+++ b/templates/calm/blame.tmpl
@@ -1,7 +1,7 @@
 [websvn-test:error]
   <div id="error">[websvn:error]</div>
 [websvn-else]
-<h2 id="pathlinks">[websvn:pathlinks] &ndash; [lang:REV] [websvn:rev]</h2>
+<h2 id="path_links">[websvn:path_links_root_config]/[websvn:path_links] &ndash; [lang:REV] [websvn:rev]</h2>
 <div id="revjump">[websvn:revision_form][lang:REV] [websvn:revision_input]<span class="submit">[websvn:revision_submit]</span>[websvn:revision_endform]</div>
   <p>
     [websvn-test:prevrevurl]

--- a/templates/calm/diff.tmpl
+++ b/templates/calm/diff.tmpl
@@ -1,7 +1,7 @@
 [websvn-test:error]
   <div id="error">[websvn:error]</div>
 [websvn-else]
-  <h2 id="pathlinks">[websvn:pathlinks] &ndash; [lang:REV] [websvn:rev2] &rarr; [websvn:rev1]</h2>
+  <h2 id="path_links">[websvn:path_links_root_config]/[websvn:path_links] &ndash; [lang:REV] [websvn:rev2] &rarr; [websvn:rev1]</h2>
   <div id="revjump">[websvn:revision_form][lang:REV] [websvn:revision_input]<span class="submit">[websvn:revision_submit]</span>[websvn:revision_endform]</div>
   <p>
     [websvn-test:prevrevurl]
@@ -36,7 +36,7 @@
     &#124; <span class="feed">[websvn:rsslink]</span>
     [websvn-endtest]
   </p>
-  
+
   [websvn-test:warning]
   <div id="warning">[websvn:warning]</div>
   [websvn-else]

--- a/templates/calm/directory.tmpl
+++ b/templates/calm/directory.tmpl
@@ -1,7 +1,7 @@
 [websvn-test:error]
    <div id="error">[websvn:error]</div>
 [websvn-else]
-<h2 id="pathlinks">[websvn:pathlinks] &ndash; [lang:REV] [websvn:rev]</h2>
+<h2 id="path_links">[websvn:path_links_root_config]/[websvn:path_links] &ndash; [lang:REV] [websvn:rev]</h2>
 <div id="revjump">[websvn:revision_form]<div>[lang:REV] [websvn:revision_input]<span class="submit">[websvn:revision_submit]</span></div>[websvn:revision_endform]</div>
 [websvn-test:search]
 <div id="searchcss">[websvn:search_form]<div>[lang:SEARCH] [websvn:search_input]<span class="submit">[websvn:search_submit]</span></div>[websvn:search_endform]</div>

--- a/templates/calm/file.tmpl
+++ b/templates/calm/file.tmpl
@@ -1,7 +1,7 @@
 [websvn-test:error]
   <div id="error">[websvn:error]</div>
 [websvn-else]
-  <h2 id="pathlinks">[websvn:pathlinks] &ndash; [lang:REV] [websvn:rev]</h2>
+  <h2 id="path_links">[websvn:path_links_root_config]/[websvn:path_links] &ndash; [lang:REV] [websvn:rev]</h2>
   <div id="revjump">[websvn:revision_form][lang:REV] [websvn:revision_input]<span class="submit">[websvn:revision_submit]</span>[websvn:revision_endform]</div>
   <p>
     [websvn-test:prevrevurl]

--- a/templates/calm/log.tmpl
+++ b/templates/calm/log.tmpl
@@ -1,7 +1,7 @@
 [websvn-test:error]
    <div id="error">[websvn:error]</div>
 [websvn-else]
-  <h2 id="pathlinks">[websvn:pathlinks] &ndash; [lang:REV] [websvn:rev]</h2>
+  <h2 id="path_links">[websvn:path_links_root_config]/[websvn:path_links] &ndash; [lang:REV] [websvn:rev]</h2>
   <div id="revjump">[websvn:revision_form]<div>[lang:REV] [websvn:revision_input]<span class="submit">[websvn:revision_submit]</span></div>[websvn:revision_endform]</div>
   <p>
     [websvn-test:goyoungestlink]
@@ -22,7 +22,7 @@
     &#124; <span class="feed">[websvn:rsslink]</span>
     [websvn-endtest]
   </p>
-  
+
   [websvn-test:warning]
   <div id="warning">[websvn:warning]</div>
   [websvn-else]
@@ -54,12 +54,12 @@
     </p>
     [websvn:logsearch_endform]
   </div>
-  
+
   <div id="wrap">
   [websvn-test:logsearch_nomatches]
      [lang:NORESULTS]
   [websvn-endtest]
-  
+
   [websvn-test:logsearch_resultsfound]
      [websvn:compare_form]
         <table>
@@ -91,13 +91,13 @@
               [websvn-test:showchanges]
               <td class="changes">
               [websvn-test:revadded]
-                <div class="add">[websvn:revadded]</div>        
+                <div class="add">[websvn:revadded]</div>
               [websvn-endtest]
               [websvn-test:revdeleted]
-                <div class="del">[websvn:revdeleted]</div>        
+                <div class="del">[websvn:revdeleted]</div>
               [websvn-endtest]
               [websvn-test:revmodified]
-                <div class="mod">[websvn:revmodified]</div>        
+                <div class="mod">[websvn:revmodified]</div>
               [websvn-endtest]
               </td>
               [websvn-endtest]
@@ -106,10 +106,10 @@
         </table>
         <p class="submit">
         [websvn:compare_submit]
-        </p>  
+        </p>
      [websvn:compare_endform]
   [websvn-endtest]
-  
+
   [websvn-test:logsearch_nomorematches]
     <p>[lang:NOMORERESULTS]</p>
   [websvn-endtest]
@@ -118,7 +118,7 @@
   [websvn-endtest]
   <p class="pagelinks">[websvn:pagelinks]</p>
   <p>[websvn:showalllink]</p>
-  
+
   [websvn-endtest]
   </div>
 [websvn-endtest]

--- a/templates/calm/revision.tmpl
+++ b/templates/calm/revision.tmpl
@@ -1,7 +1,7 @@
 [websvn-test:error]
    <div id="error">[websvn:error]</div>
 [websvn-else]
-<h2 id="pathlinks">[websvn:pathlinks] &ndash; [lang:REV] [websvn:rev]</h2>
+<h2 id="path_links">[websvn:path_links_root_config]/[websvn:path_links] &ndash; [lang:REV] [websvn:rev]</h2>
 <div id="revjump">[websvn:revision_form][lang:REV] [websvn:revision_input]<span class="submit">[websvn:revision_submit]</span>[websvn:revision_endform]</div>
 <p>
   [websvn-test:prevrevurl]

--- a/templates/calm/styles.css
+++ b/templates/calm/styles.css
@@ -570,7 +570,7 @@ tr td.feed a:link {
 /*
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ File, Blame, Diff
 */
-h2#pathlinks {
+h2#path_links {
 	text-transform:none;
 	margin:0 2% 15px;
 }
@@ -917,7 +917,7 @@ td.changes .mod {
 	tr td.path {
 		white-space: nowrap;
 	}
-	h2#pathlinks {
+	h2#path_links {
 		overflow-x: auto;
 		overflow-y: hidden;
 	}


### PR DESCRIPTION
The approach is to 1. get rid of the hard-coded string and make it a language property instead, so one can have phrases like "(root)" in English, "(wurzel)" in German or some arbitrary other string easily.

Second, a new config is introduced to let WebSVN calculate the name of that root-phrase based on the name of the current repo automatically. that might make sense for a lot of people and is what's actually requested in the linked issue by @didiez.

Third, the breadcrumb path rendered into templates has been splitted into root and non-root, so that templates can decide to use an arbitrary different root or none at all. Before, templates only received the whole rendered breadcrumb, which isn't pretty flexible. Things can easily be reverted with mass-replace anyway.

Fixes https://github.com/websvnphp/websvn/issues/150.