### PR TITLE
Added line numbers in file detail view with ids for future styling.

### DIFF
--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -684,7 +684,7 @@ class SVNRepository {
 		$shouldTrimOutput = false;
 		$explodeStr = "\n";
 		if ($highlight != 'no' && $config->useGeshi && $geshiLang = $this->highlightLanguageUsingGeshi($path)) {
-			$this->applyGeshi($path, $tempname, $geshiLang, $rev, $peg);
+			$this->applyGeshi($path, $tempname, $geshiLang, $rev, $peg, $highlight);
 			// Geshi outputs in HTML format, enscript does not
 			$shouldTrimOutput = true;
 			$explodeStr = "<br />";
@@ -780,7 +780,7 @@ class SVNRepository {
 	//
 	// perform syntax highlighting using geshi
 
-	function applyGeshi($path, $filename, $language, $rev, $peg = '', $return = false) {
+	function applyGeshi($path, $filename, $language, $rev, $peg = '', $return = false, $highlight = 'file') {
 		// Output the file to the filename
 		$error	= '';
 		$cmd	= $this->svnCommandString('cat', $path, $rev, $peg).' > '.quote($filename);
@@ -808,8 +808,10 @@ class SVNRepository {
 		$this->geshi->set_header_type(GESHI_HEADER_NONE);
 		$this->geshi->set_overall_class('geshi');
 		$this->geshi->set_tab_width($this->repConfig->getExpandTabsBy());
-		$this->geshi->enable_line_numbers(GESHI_FANCY_LINE_NUMBERS);
-		$this->geshi->enable_ids(true);
+		if ($highlight == 'file') {
+			$this->geshi->enable_line_numbers(GESHI_FANCY_LINE_NUMBERS);
+			$this->geshi->enable_ids(true);
+		}
 
 		if ($return) {
 			return $this->geshi->parse_code();

--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -812,7 +812,8 @@ class SVNRepository {
 		$this->geshi->set_tab_width($this->repConfig->getExpandTabsBy());
 
 		if ($highlight == 'file') {
-			$this->geshi->enable_line_numbers(GESHI_FANCY_LINE_NUMBERS);
+			$this->geshi->enable_line_numbers(GESHI_FANCY_LINE_NUMBERS,1);
+			$this->geshi->set_overall_id('line');
 			$this->geshi->enable_ids(true);
 		}
 

--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -808,6 +808,8 @@ class SVNRepository {
 		$this->geshi->set_header_type(GESHI_HEADER_NONE);
 		$this->geshi->set_overall_class('geshi');
 		$this->geshi->set_tab_width($this->repConfig->getExpandTabsBy());
+		$this->geshi->enable_line_numbers(GESHI_FANCY_LINE_NUMBERS);
+		$this->geshi->enable_ids(true);
 
 		if ($return) {
 			return $this->geshi->parse_code();

--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -812,8 +812,8 @@ class SVNRepository {
 		$this->geshi->set_tab_width($this->repConfig->getExpandTabsBy());
 
 		if ($highlight == 'file') {
-			$this->geshi->enable_line_numbers(GESHI_FANCY_LINE_NUMBERS,1);
-			$this->geshi->set_overall_id('line');
+			$this->geshi->enable_line_numbers(GESHI_FANCY_LINE_NUMBERS);
+			$this->geshi->set_overall_id('geshi');
 			$this->geshi->enable_ids(true);
 		}
 

--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -797,17 +797,20 @@ class SVNRepository {
 		}
 
 		$source = file_get_contents($filename);
+
 		if ($this->geshi === null) {
 			if (!defined('USE_AUTOLOADER')) {
 				require_once 'geshi.php';
 			}
 			$this->geshi = new GeSHi();
 		}
+
 		$this->geshi->set_source($source);
 		$this->geshi->set_language($language);
 		$this->geshi->set_header_type(GESHI_HEADER_NONE);
 		$this->geshi->set_overall_class('geshi');
 		$this->geshi->set_tab_width($this->repConfig->getExpandTabsBy());
+
 		if ($highlight == 'file') {
 			$this->geshi->enable_line_numbers(GESHI_FANCY_LINE_NUMBERS);
 			$this->geshi->enable_ids(true);


### PR DESCRIPTION
This is a minor enhancement. Previously the view looked like the following:
![image](https://user-images.githubusercontent.com/4973182/152655324-85598471-35ca-4034-83d6-2e2fa5885e96.png)

There were no line numbers in the file details view.

The change in the PR adds the line number and provides a basic default styling looks like the following:
![image](https://user-images.githubusercontent.com/4973182/152655358-df832cd1-2962-43e6-ae36-269aa6886734.png)


The change uses the in-built line number system provided by geshi. So viewable only if geshi is used. Same can be done for enscript but I have to read up on it.
Further added an argument highlight to the applyGeshi function to identify file and line highlighting.
The line highlighting number is taken care internally it is only during file highlighting that the line numbers are missing.