### PR TITLE
Make path for svnauthz configurable (#82)

### DIFF
--- a/include/configclass.php
+++ b/include/configclass.php
@@ -1242,24 +1242,28 @@ class WebSvnConfig {
 	// Define directory path to use for --config-dir parameter
 	function setSvnConfigDir($path) {
 		$this->_svnConfigDir = $path;
-		$this->_updateSVNCommand();
+		$this->_updateSvnCommand();
 	}
 
 	// Define flag to use --trust-server-cert parameter
 	function setTrustServerCert() {
 		$this->_svnTrustServerCert = true;
-		$this->_updateSVNCommand();
+		$this->_updateSvnCommand();
 	}
 
 	// Define the location of the svn command (e.g. '/usr/bin')
 	function setSvnCommandPath($path) {
 		$this->_svnCommandPath = $path;
-		$this->_updateSVNCommand();
+		$this->_updateSvnCommand();
 	}
 
-	function _updateSVNCommand() {
-		$this->_setPath($this->svn,			$this->_svnCommandPath, 'svn',		'--non-interactive --config-dir '.$this->_svnConfigDir.($this->_svnTrustServerCert ? ' --trust-server-cert' : ''));
-		$this->_setPath($this->svnAuthz,	$this->_svnCommandPath, 'svnauthz',	'accessof');
+	// Define the location of the svnauthz command (e.g. '/usr/bin')
+	function setSvnAuthzCommandPath($path) {
+		$this->_setPath($this->svnAuthz, $path, 'svnauthz', 'accessof');
+	}
+
+	function _updateSvnCommand() {
+		$this->_setPath($this->svn, $this->_svnCommandPath, 'svn', '--non-interactive --config-dir '.$this->_svnConfigDir.($this->_svnTrustServerCert ? ' --trust-server-cert' : ''));
 	}
 
 	function getSvnCommand() {

--- a/include/distconfig.php
+++ b/include/distconfig.php
@@ -37,7 +37,8 @@
 
 // Configure these lines if your commands aren't on your path.
 //
-// $config->setSVNCommandPath('/path/to/svn/command/'); //  e.g. c:\\program files\\subversion\\bin
+// $config->setSvnCommandPath('/path/to/svn/command/'); //  e.g. c:\\program files\\subversion\\bin
+// $config->setSvnAuthzCommandPath('/path/to/svnauthz/command/'); //  e.g. c:\\program files\\subversion\\bin\tools
 // $config->setDiffPath('/path/to/diff/command/');
 
 // For syntax colouring, if option enabled...


### PR DESCRIPTION
By default svnauthz is not installed into bin/, but to a different
directly usually not in PATH. Make this configurable for the admin.

This closes #82