### PR TITLE
Remove warning "Undefined constant "removeDirectory""

### DIFF
--- a/include/utils.php
+++ b/include/utils.php
@@ -456,7 +456,7 @@ function tempnamWithCheck($dir, $prefix, $rmOnShutdown = true) {
 	}
 	if ($tmp && $rmOnShutdown)
 	{
-		register_shutdown_function(removeDirectory, $tmp);
+		register_shutdown_function('removeDirectory', $tmp);
 		return $tmp;
 	}
 


### PR DESCRIPTION
Remove a php Warning:

> Undefined constant "removeDirectory" in /var/www/websvn/include/utils.php

This fixes https://github.com/websvnphp/websvn/issues/165.