### PR TITLE
Add .jmx file extension for XML

### DIFF
--- a/include/setup.php
+++ b/include/setup.php
@@ -314,7 +314,7 @@ $extGeshi = array(
 	'vhdl'			=> array('vhd', 'vhdl'),
 	'vim'			=> array('vim'),
 	'whitespace'	=> array('ws'),
-	'xml'			=> array('xml', 'xsl', 'xsd', 'xib', 'wsdl', 'svg', 'plist'),
+	'xml'			=> array('xml', 'xsl', 'xsd', 'xib', 'wsdl', 'svg', 'plist','jmx'),
 	'z80'			=> array('z80'),
 );
 


### PR DESCRIPTION
Apache JMeter uses .jmx as default extension for its test plans.