### PR TITLE
Last PHP 7.x compatible fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+composer.lock

--- a/comp.php
+++ b/comp.php
@@ -100,7 +100,7 @@ $vars['rev1url'] = $config->getURL($rep, $path1, 'dir').createRevAndPegString($r
 $vars['rev2url'] = $config->getURL($rep, $path2, 'dir').createRevAndPegString($rev2, $rev2);
 
 $url = $config->getURL($rep, '', 'comp');
-$vars['reverselink'] = '<a href="'.$url.'compare%5B%5D='.urlencode($path2).'@'.$rev2.'&amp;compare%5B%5D='.urlencode($path1).'@'.$rev1.'&amp;manualorder=1'.($ignoreWhitespace ? '&amp;ignorews=1' : '').'">'.$lang['REVCOMP'].'</a>';
+$vars['reverselink'] = '<a href="'.$url.'compare%5B%5D='.rawurlencode($path2).'@'.$rev2.'&amp;compare%5B%5D='.rawurlencode($path1).'@'.$rev1.'&amp;manualorder=1'.($ignoreWhitespace ? '&amp;ignorews=1' : '').'">'.$lang['REVCOMP'].'</a>';
 $toggleIgnoreWhitespace = '';
 
 if ($ignoreWhitespace == $config->getIgnoreWhitespacesInDiff()) 
@@ -110,11 +110,11 @@ if ($ignoreWhitespace == $config->getIgnoreWhitespacesInDiff())
 
 if (!$ignoreWhitespace) 
 {
-	$vars['ignorewhitespacelink'] = '<a href="'.$url.'compare%5B%5D='.urlencode($path1).'@'.$rev1.'&amp;compare%5B%5D='.urlencode($path2).'@'.$rev2.($manualorder ? '&amp;manualorder=1' : '').$toggleIgnoreWhitespace.'">'.$lang['IGNOREWHITESPACE'].'</a>';
+	$vars['ignorewhitespacelink'] = '<a href="'.$url.'compare%5B%5D='.rawurlencode($path1).'@'.$rev1.'&amp;compare%5B%5D='.rawurlencode($path2).'@'.$rev2.($manualorder ? '&amp;manualorder=1' : '').$toggleIgnoreWhitespace.'">'.$lang['IGNOREWHITESPACE'].'</a>';
 }
 else 
 {
-	$vars['regardwhitespacelink'] = '<a href="'.$url.'compare%5B%5D='.urlencode($path1).'@'.$rev1.'&amp;compare%5B%5D='.urlencode($path2).'@'.$rev2.($manualorder ? '&amp;manualorder=1' : '').$toggleIgnoreWhitespace.'">'.$lang['REGARDWHITESPACE'].'</a>';
+	$vars['regardwhitespacelink'] = '<a href="'.$url.'compare%5B%5D='.rawurlencode($path1).'@'.$rev1.'&amp;compare%5B%5D='.rawurlencode($path2).'@'.$rev2.($manualorder ? '&amp;manualorder=1' : '').$toggleIgnoreWhitespace.'">'.$lang['REGARDWHITESPACE'].'</a>';
 }
 
 if ($rev1 == 0) $rev1 = 'HEAD';

--- a/comp.php
+++ b/comp.php
@@ -59,22 +59,22 @@ if (array_key_exists('ignorews', $_REQUEST))
 }
 
 // Some page links put the revision with the path...
-if (strpos($path1, '@')) 
+if ($path1 && strpos($path1, '@'))
 {
 	list($path1, $rev1) = explode('@', $path1);
 }
-else if (strpos($path1, '@') === 0) 
+else if ($path1 && (strpos($path1, '@') === 0))
 {
 	// Something went wrong. The path is missing.
 	$rev1 = substr($path1, 1);
 	$path1 = '/';
 }
 
-if (strpos($path2, '@')) 
+if ($path2 && strpos($path2, '@'))
 {
 	list($path2, $rev2) = explode('@', $path2);
 }
-else if (strpos($path2, '@') === 0) 
+else if ($path2 && (strpos($path2, '@') === 0))
 {
 	$rev2 = substr($path2, 1);
 	$path2 = '/';

--- a/comp.php
+++ b/comp.php
@@ -100,7 +100,7 @@ $vars['rev1url'] = $config->getURL($rep, $path1, 'dir').createRevAndPegString($r
 $vars['rev2url'] = $config->getURL($rep, $path2, 'dir').createRevAndPegString($rev2, $rev2);
 
 $url = $config->getURL($rep, '', 'comp');
-$vars['reverselink'] = '<a href="'.$url.'compare%5B%5D='.rawurlencode($path2).'@'.$rev2.'&amp;compare%5B%5D='.rawurlencode($path1).'@'.$rev1.'&amp;manualorder=1'.($ignoreWhitespace ? '&amp;ignorews=1' : '').'">'.$lang['REVCOMP'].'</a>';
+$vars['reverselink'] = '<a href="'.$url.'compare%5B%5D='.rawurlencode($path2 ?? '').'@'.$rev2.'&amp;compare%5B%5D='.rawurlencode($path1 ?? '').'@'.$rev1.'&amp;manualorder=1'.($ignoreWhitespace ? '&amp;ignorews=1' : '').'">'.$lang['REVCOMP'].'</a>';
 $toggleIgnoreWhitespace = '';
 
 if ($ignoreWhitespace == $config->getIgnoreWhitespacesInDiff()) 
@@ -110,11 +110,11 @@ if ($ignoreWhitespace == $config->getIgnoreWhitespacesInDiff())
 
 if (!$ignoreWhitespace) 
 {
-	$vars['ignorewhitespacelink'] = '<a href="'.$url.'compare%5B%5D='.rawurlencode($path1).'@'.$rev1.'&amp;compare%5B%5D='.rawurlencode($path2).'@'.$rev2.($manualorder ? '&amp;manualorder=1' : '').$toggleIgnoreWhitespace.'">'.$lang['IGNOREWHITESPACE'].'</a>';
+	$vars['ignorewhitespacelink'] = '<a href="'.$url.'compare%5B%5D='.rawurlencode($path1 ?? '').'@'.$rev1.'&amp;compare%5B%5D='.rawurlencode($path2 ?? '').'@'.$rev2.($manualorder ? '&amp;manualorder=1' : '').$toggleIgnoreWhitespace.'">'.$lang['IGNOREWHITESPACE'].'</a>';
 }
 else 
 {
-	$vars['regardwhitespacelink'] = '<a href="'.$url.'compare%5B%5D='.rawurlencode($path1).'@'.$rev1.'&amp;compare%5B%5D='.rawurlencode($path2).'@'.$rev2.($manualorder ? '&amp;manualorder=1' : '').$toggleIgnoreWhitespace.'">'.$lang['REGARDWHITESPACE'].'</a>';
+	$vars['regardwhitespacelink'] = '<a href="'.$url.'compare%5B%5D='.rawurlencode($path1 ?? '').'@'.$rev1.'&amp;compare%5B%5D='.rawurlencode($path2 ?? '').'@'.$rev2.($manualorder ? '&amp;manualorder=1' : '').$toggleIgnoreWhitespace.'">'.$lang['REGARDWHITESPACE'].'</a>';
 }
 
 if ($rev1 == 0) $rev1 = 'HEAD';

--- a/comp.php
+++ b/comp.php
@@ -187,8 +187,8 @@ $noinput = empty($path1) || empty($path2);
 $relativePath1 = $path1;
 $relativePath2 = $path2;
 
-$svnpath1 = encodepath($svnrep->getSvnPath(str_replace(DIRECTORY_SEPARATOR, '/', $path1)));
-$svnpath2 = encodepath($svnrep->getSvnPath(str_replace(DIRECTORY_SEPARATOR, '/', $path2)));
+$svnpath1 = encodepath($svnrep->getSvnPath(str_replace(DIRECTORY_SEPARATOR, '/', $path1 ?? '')));
+$svnpath2 = encodepath($svnrep->getSvnPath(str_replace(DIRECTORY_SEPARATOR, '/', $path2 ?? '')));
 
 $debug = false;
 

--- a/comp.php
+++ b/comp.php
@@ -406,7 +406,7 @@ if (!$noinput)
 						$line = fgets($diff);
 						if ($debug) print 'Ignoring: "'.$line.'"<br />';
 
-						while ($line[0] == ' ' || $line[0] == '+' || $line[0] == '-') 
+						while ($line && ($line[0] == ' ' || $line[0] == '+' || $line[0] == '-'))
 						{
 							$line = fgets($diff);
 							if ($debug) print 'Ignoring: "'.$line.'"<br />';

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
     "keywords": ["subversion", "svn", "websvn"],
     "type": "project",
     "require": {
-        "geshi/geshi": "^1.0.9",
-        "pear/archive_tar": "^1.4",
-        "pear/text_diff": "^1.2",
-        "erusev/parsedown": "^1.7"
+        "geshi/geshi": "^1.0.9.1",
+        "pear/archive_tar": "^1.4.14",
+        "pear/text_diff": "^1.2.2",
+        "erusev/parsedown": "^2.0.0-beta-1"
     }
 }

--- a/dl.php
+++ b/dl.php
@@ -83,7 +83,7 @@ else
 	$history = $svnrep->getLog($path, $rev, $rev - 1, true, 1, $peg);
 }
 
-$logEntry = ($history) ? $history->entries[0] : null;
+$logEntry = ($history && !empty($history->entries)) ? $history->entries[0] : null;
 
 if (!$logEntry)
 {

--- a/include/authz.php
+++ b/include/authz.php
@@ -68,7 +68,7 @@ class Authorization {
 		$username		= !$this->hasUsername()	? '' : '--username ' . quote($this->user);
 		$subDirs		= !$checkSubDirs		? '' : '-R';
 		$authzFile		= quote($this->accessFile);
-		$retVal			= "${cmd} ${repoAndPath} ${username} ${subDirs} ${authzFile}";
+		$retVal			= "{$cmd} {$repoAndPath} {$username} {$subDirs} {$authzFile}";
 
 		return $retVal;
 	}

--- a/include/command.php
+++ b/include/command.php
@@ -82,7 +82,7 @@ function escape($str) {
 	$entities['>'] = '&gt;';
 	$entities['"'] = '&quot;';
 	$entities['\''] = '&apos;';
-	return str_replace(array_keys($entities), array_values($entities), $str);
+	return str_replace(array_keys($entities), array_values($entities), $str ?? '');
 }
 
 // }}}

--- a/include/configclass.php
+++ b/include/configclass.php
@@ -32,7 +32,7 @@ require_once 'include/version.php';
 
 function cmpReps($a, $b) {
 	// First, sort by group
-	$g = strcasecmp($a->group, $b->group);
+	$g = strcasecmp((string) $a->group, (string) $b->group);
 	if ($g) return $g;
 
 	// Same group? Sort by name
@@ -44,7 +44,7 @@ function cmpReps($a, $b) {
 // {{{ cmpGroups($a, $b)
 
 function cmpGroups($a, $b) {
-	$g = strcasecmp($a->group, $b->group);
+	$g = strcasecmp((string) $a->group, (string) $b->group);
 	if ($g) return $g;
 
 	return 0;

--- a/include/configclass.php
+++ b/include/configclass.php
@@ -1102,7 +1102,7 @@ class WebSvnConfig {
 		list($base, $params) = $this->getUrlParts($rep, $path, $op);
 		$url = $base.'?';
 		foreach ($params as $k => $v) {
-			$url .= $k.'='.urlencode($v).'&amp;';
+			$url .= $k.'='.rawurlencode($v).'&amp;';
 		}
 		return $url;
 	}

--- a/include/configclass.php
+++ b/include/configclass.php
@@ -1134,7 +1134,7 @@ class WebSvnConfig {
 			if ($op == 'index') {
 				$url .= '/';
 			} else if (is_object($rep)) {
-				$url .= '/'.$rep->getDisplayName().str_replace('%2F', '/', rawurlencode($path));
+				$url .= '/'.$rep->getDisplayName().str_replace('%2F', '/', rawurlencode($path ?? ''));
 
 				if ($op && $op != 'dir' && $op != 'file') {
 					$params['op'] = $op;

--- a/include/diff_inc.php
+++ b/include/diff_inc.php
@@ -261,7 +261,7 @@ function command_diff($all, $ignoreWhitespace, $highlighted, $newtname, $oldtnam
 
 	// Open a pipe to the diff command with $context lines of context:
 	$cmd	= $config->diff.$whitespaceFlag.' -U '.$context.' "'.$oldtname.'" "'.$newtname.'"';
-	$diff	= runCommand($cmd);
+	$diff	= runCommand($cmd, true);
 
 	// Ignore the 3 header lines:
 	$line = array_shift($diff);

--- a/include/diff_util.php
+++ b/include/diff_util.php
@@ -45,6 +45,8 @@ class LineDiffInterface {
 // Default line diffing function
 class LineDiff extends LineDiffInterface {
 
+	private bool $ignoreWhitespace;
+
 	function __construct($ignoreWhitespace) {
 		$this->ignoreWhitespace = $ignoreWhitespace;
 	}

--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -517,7 +517,7 @@ function encodePath($uri) {
 	$parts = explode('/', $uri);
 	$partscount = count($parts);
 	for ($i = 0; $i < $partscount; $i++) {
-		// do not urlencode the 'svn+ssh://' part!
+		// do not rawurlencode the 'svn+ssh://' part!
 		if ($i != 0 || $parts[$i] != 'svn+ssh:') {
 			$parts[$i] = rawurlencode($parts[$i]);
 		}

--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -293,7 +293,7 @@ function listCharacterData($parser, $data) {
 
 			$committime = parseSvnTimestamp($data);
 			$curList->curEntry->committime = $committime;
-			$curList->curEntry->date = strftime('%Y-%m-%d %H:%M:%S', $committime);
+			$curList->curEntry->date = date('Y-m-d H:i:s', $committime);
 			$curList->curEntry->age = datetimeFormatDuration(max(time() - $committime, 0), true, true);
 			break;
 	}
@@ -444,7 +444,7 @@ function logCharacterData($parser, $data) {
 
 			$committime = parseSvnTimestamp($data);
 			$curLog->curEntry->committime = $committime;
-			$curLog->curEntry->date = strftime('%Y-%m-%d %H:%M:%S', $committime);
+			$curLog->curEntry->date = date('Y-m-d H:i:s', $committime);
 			$curLog->curEntry->age = datetimeFormatDuration(max(time() - $committime, 0), true, true);
 			break;
 

--- a/include/utils.php
+++ b/include/utils.php
@@ -344,13 +344,13 @@ function buildQuery($data, $separator = '&amp;', $key = '') {
 		$data = get_object_vars($data);
 	$p = array();
 	foreach ($data as $k => $v) {
-		$k = urlencode($k);
+		$k = rawurlencode($k);
 		if (!empty($key))
 			$k = $key.'['.$k.']';
 		if (is_array($v) || is_object($v)) {
 			$p[] = buildQuery($v, $separator, $k);
 		} else {
-			$p[] = $k.'='.urlencode($v);
+			$p[] = $k.'='.rawurlencode($v);
 		}
 	}
 	return implode($separator, $p);

--- a/include/utils.php
+++ b/include/utils.php
@@ -50,8 +50,8 @@ function createPathLinks($rep, $path, $rev, $peg = '') {
 	$rootName = $lang['BREADCRUMB_REPO_ROOT'];
 
 	$vars['path_links']				= '';
-	$vars['path_links_root_root']	= "<a href=\"${pathSoFarURL}\" class=\"root\"><span>${rootName}</span></a>";
-	$vars['path_links_root_repo']	= "<a href=\"${pathSoFarURL}\" class=\"root\"><span>${repoName}</span></a>";
+	$vars['path_links_root_root']	= "<a href=\"{$pathSoFarURL}\" class=\"root\"><span>{$rootName}</span></a>";
+	$vars['path_links_root_repo']	= "<a href=\"{$pathSoFarURL}\" class=\"root\"><span>{$repoName}</span></a>";
 	$vars['path_links_root_config']	= $config->getBreadcrumbRepoRootAsRepo()
 										? $vars['path_links_root_repo']
 										: $vars['path_links_root_root'];

--- a/listing.php
+++ b/listing.php
@@ -591,7 +591,7 @@ $vars['revlink'] = '<a href="'.$vars['revurl'].'">'.$lang['LASTMOD'].'</a>';
 
 if ($history && count($history->entries) > 1)
 {
-	$vars['compareurl'] = $config->getURL($rep, '', 'comp').'compare[]='.urlencode($history->entries[1]->path).'@'.$history->entries[1]->rev. '&amp;compare[]='.urlencode($history->entries[0]->path).'@'.$history->entries[0]->rev;
+	$vars['compareurl'] = $config->getURL($rep, '', 'comp').'compare[]='.rawurlencode($history->entries[1]->path).'@'.$history->entries[1]->rev. '&amp;compare[]='.rawurlencode($history->entries[0]->path).'@'.$history->entries[0]->rev;
 	$vars['comparelink'] = '<a href="'.$vars['compareurl'].'">'.$lang['DIFFPREV'].'</a>';
 }
 

--- a/log.php
+++ b/log.php
@@ -41,13 +41,13 @@ else
 	$showchanges = $rep->logsShowChanges();
 }
 
-$search = trim(@$_REQUEST['search']);
+$search = trim((string) @$_REQUEST['search']);
 $dosearch = strlen($search) > 0;
 
 $words = preg_split('#\s+#', $search);
 $fromRev = (int)@$_REQUEST['fr'];
-$startrev = strtoupper(trim(@$_REQUEST['sr']));
-$endrev = strtoupper(trim(@$_REQUEST['er']));
+$startrev = strtoupper(trim((string) @$_REQUEST['sr']));
+$endrev = strtoupper(trim((string) @$_REQUEST['er']));
 $max = isset($_REQUEST['max']) ? (int)$_REQUEST['max'] : false;
 
 // Max number of results to find at a time

--- a/revision.php
+++ b/revision.php
@@ -207,7 +207,7 @@ foreach ($changes as $change)
 
 if (isset($prevRev)) 
 {
-	$vars['compareurl'] = $config->getURL($rep, '', 'comp').'compare[]='.urlencode($prevPath).'@'.$prevRev. '&amp;compare[]='.urlencode($path).'@'.$rev;
+	$vars['compareurl'] = $config->getURL($rep, '', 'comp').'compare[]='.rawurlencode($prevPath).'@'.$prevRev. '&amp;compare[]='.rawurlencode($path).'@'.$rev;
 	$vars['comparelink'] = '<a href="'.$vars['compareurl'].'">'.$lang['DIFFPREV'].'</a>';
 }
 

--- a/search.php
+++ b/search.php
@@ -333,7 +333,7 @@ $vars['revlink'] = '<a href="'.$vars['revurl'].'">'.$lang['LASTMOD'].'</a>';
 
 if ($history && count($history->entries) > 1)
 {
-	$vars['compareurl'] = $config->getURL($rep, '', 'comp').'compare[]='.urlencode($history->entries[1]->path).'@'.$history->entries[1]->rev. '&amp;compare[]='.urlencode($history->entries[0]->path).'@'.$history->entries[0]->rev;
+	$vars['compareurl'] = $config->getURL($rep, '', 'comp').'compare[]='.rawurlencode($history->entries[1]->path).'@'.$history->entries[1]->rev. '&amp;compare[]='.rawurlencode($history->entries[0]->path).'@'.$history->entries[0]->rev;
 	$vars['comparelink'] = '<a href="'.$vars['compareurl'].'">'.$lang['DIFFPREV'].'</a>';
 }
 

--- a/templates/BlueGrey/blame.tmpl
+++ b/templates/BlueGrey/blame.tmpl
@@ -51,7 +51,7 @@
       <tr class="[websvn:row_class]">
         <th>[websvn:revision]</th>
         <th>[websvn:author]</th>
-        <th><a name="l[websvn:lineno]">[websvn:lineno]</a></th>
+        <th><a name="l[websvn:lineno]" href="#l[websvn:lineno]">[websvn:lineno]</a></th>
         <td>[websvn:line]</td>
       </tr>
       [websvn-endlisting]

--- a/templates/Elegant/blame.tmpl
+++ b/templates/Elegant/blame.tmpl
@@ -52,7 +52,7 @@
       <tr class="[websvn:row_class]">
         <td class="rev">[websvn:revision]</td>
         <td class="author">[websvn:author]</td>
-        <td class="line"><a name="l[websvn:lineno]"></a>[websvn:lineno]</td>
+        <td class="line"><a name="l[websvn:lineno]" href="#l[websvn:lineno]"></a>[websvn:lineno]</td>
         <td class="code">[websvn:line]</td>
       </tr>
       [websvn-endlisting]

--- a/templates/calm/blame.tmpl
+++ b/templates/calm/blame.tmpl
@@ -44,7 +44,7 @@
         <tr valign="middle">
            <td>[websvn:revision]</td>
            <td>[websvn:author]</td>
-           <td><a name="l[websvn:lineno]">[websvn:lineno]</a></td>
+           <td><a name="l[websvn:lineno]" href="#l[websvn:lineno]">[websvn:lineno]</a></td>
            <td class="code"><pre>[websvn:line]</pre></td>
         </tr>
   [websvn-endlisting]

--- a/templates/calm/styles.css
+++ b/templates/calm/styles.css
@@ -580,8 +580,6 @@ div.listing {
 	text-align:left;
 	margin:0 2%;
 	padding:3px;
-	padding-right:20px;
-	padding-bottom:20px;
 	background:#f8f8f8;
 }
 pre a, td.code pre a {


### PR DESCRIPTION
Changes which improve PHP 8 compat, but still work on PHP 7.4. #171 I will handle separately. Migration to Horde_Text_Diff requires more testing and thought and will be done separately. I hope I can move to Horde_Text_Diff with PHP 7.4 and still supoprting both: PEAR and composer.

Put this already in production tested several repos and no issues so far. Verified with:
```
PHP Version 7.4.30
FreeBSD deblndw011x.ad001.siemens.net 12.3-STABLE FreeBSD 12.3-STABLE GENERIC amd64
```

Compiled from ports:
```
'./configure'   '--with-layout=GNU' '--with-config-file-scan-dir=/usr/local/etc/php'  '--disable-all' '--with-libxml' '--with-password-argon2=/usr/local'  '--program-prefix=' '--disable-cgi' '--disable-cli' '--enable-dtrace'  '--enable-mysqlnd' '--with-apxs2=/usr/local/sbin/apxs'  '--prefix=/usr/local' '--localstatedir=/var' '--mandir=/usr/local/man'  '--infodir=/usr/local/share/info/' '--build=amd64-portbld-freebsd12.3'  'build_alias=amd64-portbld-freebsd12.3' 'PKG_CONFIG=pkgconf'  'PKG_CONFIG_LIBDIR=/usr/ports/www/mod_php74/work/.pkgconfig:/usr/local/libdata/pkgconfig:/usr/libdata/pkgconfig'  'CFLAGS=-O2 -pipe -fstack-protector-strong -fno-strict-aliasing '  'CPP=cpp' 'CXXFLAGS=-O2 -pipe -fstack-protector-strong  -fno-strict-aliasing '
```