### PR TITLE
Replace Text_Diff with Horde_Text_Diff

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "require": {
         "geshi/geshi": "^1.0.9.1",
         "pear/archive_tar": "^1.4.14",
-        "pear/text_diff": "^1.2.2",
-        "erusev/parsedown": "^1.7.4"
-    }
+        "horde/text_diff": "^3.0.0",
+        "erusev/parsedown": "1.7.4"
+    },
+    "minimum-stability": "alpha"
 }

--- a/include/diff_inc.php
+++ b/include/diff_inc.php
@@ -23,9 +23,17 @@
 // Diff to files
 
 if (!defined('USE_AUTOLOADER')) {
-	@include_once 'Text/Diff.php';
-	@include_once 'Text/Diff/Renderer.php';
-	@include_once 'Text/Diff/Renderer/unified.php';
+	@include_once 'Horde/String.php';
+	@include_once 'Horde/Text/Diff.php';
+	@include_once 'Horde/Text/Diff/Mapped.php';
+	@include_once 'Horde/Text/Diff/Engine/Native.php';
+	@include_once 'Horde/Text/Diff/Op/Base.php';
+	@include_once 'Horde/Text/Diff/Op/Copy.php';
+	@include_once 'Horde/Text/Diff/Op/Delete.php';
+	@include_once 'Horde/Text/Diff/Op/Add.php';
+	@include_once 'Horde/Text/Diff/Op/Change.php';
+	@include_once 'Horde/Text/Diff/Renderer.php';
+	@include_once 'Horde/Text/Diff/Renderer/Unified.php';
 }
 include_once 'include/diff_util.php';
 
@@ -298,7 +306,7 @@ function inline_diff($all, $ignoreWhitespace, $highlighted, $newtname, $oldtname
 	$fromLines = file($oldtname);
 	$toLines = file($newtname);
 	if (!$ignoreWhitespace) {
-		$diff = @new Text_Diff('auto', array($fromLines, $toLines));
+		$diff = new Horde_Text_Diff('Native', array($fromLines, $toLines));
 	} else {
 		$whitespaces = array(' ', "\t", "\n", "\r");
 		$mappedFromLines = array();
@@ -313,9 +321,9 @@ function inline_diff($all, $ignoreWhitespace, $highlighted, $newtname, $oldtname
 			$toLines[$k] = $line;
 			$mappedToLines[] = str_replace($whitespaces, array(), $line);
 		}
-		$diff = @new Text_MappedDiff($fromLines, $toLines, $mappedFromLines, $mappedToLines);
+		$diff = new Horde_Text_Diff_Mapped('Native', array($fromLines, $toLines, $mappedFromLines, $mappedToLines));
 	}
-	$renderer = new Text_Diff_Renderer_unified(array('leading_context_lines' => $context, 'trailing_context_lines' => $context));
+	$renderer = new Horde_Text_Diff_Renderer_Unified(array('leading_context_lines' => $context, 'trailing_context_lines' => $context));
 	$rendered = explode("\n", $renderer->render($diff));
 
 	// restore previous error reporting level
@@ -333,8 +341,9 @@ function inline_diff($all, $ignoreWhitespace, $highlighted, $newtname, $oldtname
 }
 
 function do_diff($all, $ignoreWhitespace, $highlighted, $newtname, $oldtname, $newhlname, $oldhlname) {
-	if (class_exists('Text_Diff')) {
-		return inline_diff($all, $ignoreWhitespace, $highlighted, $newtname, $oldtname, $newhlname, $oldhlname);
+	if ((!$ignoreWhitespace ? class_exists('Horde_Text_Diff') : class_exists('Horde_Text_Diff_Mapped'))
+           && class_exists('Horde_Text_Diff_Renderer_Unified')) {
+		   return inline_diff($all, $ignoreWhitespace, $highlighted, $newtname, $oldtname, $newhlname, $oldhlname);
 	} else {
 		return command_diff($all, $ignoreWhitespace, $highlighted, $newtname, $oldtname, $newhlname, $oldhlname);
 	}

--- a/include/diff_util.php
+++ b/include/diff_util.php
@@ -22,11 +22,8 @@
 //
 // help diff_inc.php to make sensible changes from added and deleted diff lines
 // These lines are automatically paired and also inline diff is performed to show
-// insertions/deletions on one line
-
-if (!defined('USE_AUTOLOADER')) {
-	@include_once 'Text/Diff.php';
-}
+// insertions/deletions on one line. diff_inc.php must have all Horde_Text_Diff
+// requirements met (include_once statements).
 
 // Interface for diffing function
 class LineDiffInterface {
@@ -167,8 +164,8 @@ class LineDiff extends LineDiffInterface {
 			$do_diff = false;
 		}
 
-		// Exit gracefully if loading of Text_Diff failed
-		if (!class_exists('Text_Diff') || !class_exists('Text_MappedDiff')) {
+		// Exit gracefully if loading of Horde_Text_Diff failed
+		if (!class_exists('Horde_Text_Diff') || !class_exists('Horde_Text_Diff_Mapped')) {
 			$do_diff = false;
 		}
 
@@ -181,7 +178,7 @@ class LineDiff extends LineDiffInterface {
 		$tokens2 = $this->tokenize($highlighted2, $highlighted, $this->ignoreWhitespace);
 
 		if (!$this->ignoreWhitespace) {
-			$diff = @new Text_Diff('native', array($tokens1, $tokens2));
+			$diff = new Horde_Text_Diff('Native', array($tokens1, $tokens2));
 		} else {
 			// we need to create mapped parts for MappedDiff
 			$mapped1 = array();
@@ -192,7 +189,7 @@ class LineDiff extends LineDiffInterface {
 			foreach ($tokens2 as $token) {
 				$mapped2[] = str_replace($whitespaces, array(), $token);
 			}
-			$diff = @new Text_MappedDiff($tokens1, $tokens2, $mapped1, $mapped2);
+			$diff = new Horde_Text_Diff_Mapped('Native', array($tokens1, $tokens2, $mapped1, $mapped2));
 		}
 
 		// now, get the diff and annotate text
@@ -201,14 +198,14 @@ class LineDiff extends LineDiffInterface {
 		$line1 = '';
 		$line2 = '';
 		foreach ($edits as $edit) {
-			if (@is_a($edit, 'Text_Diff_Op_copy')) {
+			if ($edit instanceof Horde_Text_Diff_Op_Copy) {
 				$line1 .= implode('', $edit->orig);
 				$line2 .= implode('', $edit->final);
-			} else if (@is_a($edit, 'Text_Diff_Op_delete')) {
+			} else if ($edit instanceof Horde_Text_Diff_Op_Delete) {
 				$line1 .= '<del>'.implode('', $edit->orig).'</del>';
-			} else if (@is_a($edit, 'Text_Diff_Op_add')) {
+			} else if ($edit instanceof Horde_Text_Diff_Op_Add) {
 				$line2 .= '<ins>'.implode('', $edit->final).'</ins>';
-			} else if (@is_a($edit, 'Text_Diff_Op_change')) {
+			} else if ($edit instanceof Horde_Text_Diff_Op_Change) {
 				$line1 .= '<del>'.implode('', $edit->orig).'</del>';
 				$line2 .= '<ins>'.implode('', $edit->final).'</ins>';
 			} else {


### PR DESCRIPTION
Text_Diff has been superseded by Horde_Text_Diff long time ago. This change supports last version (2.2.1) of Horde_Text_Diff available through the Horde PEAR channel and as well as the fork from
https://github.com/maintaina-com/Text_Diff which fully covers PHP 8.