### PR TITLE
Blame is broken when GeSHi is highlighting XML (#171)

### DIFF
--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -684,7 +684,7 @@ class SVNRepository {
 		$shouldTrimOutput = false;
 		$explodeStr = "\n";
 		if ($highlight != 'no' && $config->useGeshi && $geshiLang = $this->highlightLanguageUsingGeshi($path)) {
-			$this->applyGeshi($path, $tempname, $geshiLang, $rev, $peg, $highlight);
+			$this->applyGeshi($path, $tempname, $geshiLang, $rev, $peg, false, $highlight);
 			// Geshi outputs in HTML format, enscript does not
 			$shouldTrimOutput = true;
 			$explodeStr = "<br />";


### PR DESCRIPTION
Incorrect arguments were passed to the function appyGeshi()