### PR TITLE
Remove custom str_split() implementation

### DIFF
--- a/include/diff_util.php
+++ b/include/diff_util.php
@@ -365,14 +365,3 @@ class SensibleLineChanges {
 	}
 }
 
-if (!function_exists('str_split')) {
-	function str_split($string, $string_length = 1) {
-		if ($string_length < 1) return false;
-		$parts = array();
-		do {
-			$parts[] = substr($string, 0, $string_length);
-			$string = substr($string, $string_length);
-		} while ($string !== false);
-		return $parts;
-	}
-}


### PR DESCRIPTION
Since PHP 5 str_split() is included. No need for a custom implementation anymore.