### PR TITLE
Properly and consistently strip only CRLF at end

### DIFF
--- a/blame.php
+++ b/blame.php
@@ -181,7 +181,7 @@ else
 
 			while (!feof($blame) && !feof($file)) 
 			{
-				$blameline = fgets($blame);
+				$blameline = rtrim(fgets($blame), "\n\r");
 
 				if ($blameline != '') 
 				{
@@ -207,7 +207,7 @@ else
 					$listvar['row_class'] = $row_class;
 					$last_rev = $revision;
 
-					$line = rtrim(fgets($file));
+					$line = rtrim(fgets($file), "\n\r");
 					if (!$highlighted)
 					{
 						$line = escape(toOutputEncoding($line));

--- a/comp.php
+++ b/comp.php
@@ -326,7 +326,7 @@ if (!$noinput)
 			{
 				if ($bufferedLine === false) 
 				{
-					$bufferedLine = rtrim(fgets($diff), "\r\n");
+					$bufferedLine = rtrim(fgets($diff), "\n\r");
 				}
 
 				$newlineR = strpos($bufferedLine, "\r");
@@ -494,7 +494,7 @@ if (!$noinput)
 				{
 					$index++;
 					clearVars();
-					$listing[$index++]['info'] = escape(toOutputEncoding($line));
+					$listing[$index++]['info'] = escape(toOutputEncoding(rtrim($line, "\n\r")));
 					continue;
 				}
 
@@ -537,13 +537,13 @@ if (!$noinput)
 				$line = fgets($diff);
 				if ($debug) print 'Skipping: '.$line.'<br />';
 
-				while ($line = trim(fgets($diff))) 
+				while ($line = rtrim(fgets($diff), "\n\r"))
 				{
-					if (!strncmp($line, 'Index: ', 7)) 
+					if (!strncmp(trim($line), 'Index: ', 7))
 					{
 						break;
 					}
-					if (!strncmp($line, '##', 2) || $line == '\ No newline at end of file') 
+					if (!strncmp(trim($line), '##', 2) || $line == '\ No newline at end of file')
 					{
 						continue;
 					}

--- a/include/command.php
+++ b/include/command.php
@@ -142,14 +142,14 @@ function runCommand($cmd, $mayReturnNothing = false, &$errorIf = 'NOT_USED') {
 	$firstline	= true;
 
 	while (!feof($handle)) {
-		$line = fgets($handle);
+		$line = rtrim(fgets($handle), "\n\r");
 		if ($firstline && empty($line) && !$mayReturnNothing) {
 			$error = 'No output on STDOUT.';
 			break;
 		}
 
 		$firstline	= false;
-		$output[]	= toOutputEncoding(rtrim($line));
+		$output[]	= toOutputEncoding($line);
 	}
 
 	while (!feof($pipes[2])) {

--- a/include/diff_inc.php
+++ b/include/diff_inc.php
@@ -175,7 +175,7 @@ function diff_result($all, $highlighted, $newtname, $oldtname, $obj, $ignoreWhit
 				$fin = true;
 			} else {
 				$mod = $line[0];
-				$line = rtrim(substr($line, 1));
+				$line = substr($line, 1);
 
 				switch ($mod) {
 					case '-':
@@ -195,7 +195,6 @@ function diff_result($all, $highlighted, $newtname, $oldtname, $obj, $ignoreWhit
 
 						$text1 = getWrappedLineFromFile($ofile, $highlighted);
 						$text2 = getWrappedLineFromFile($nfile, $highlighted);
-
 						$listingHelper->addLine($text1, $curoline, $text2, $curnline);
 
 						$curoline++;

--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -288,9 +288,7 @@ function listCharacterData($parser, $data) {
 
 		case 'DATE':
 			if ($debugxml) print 'Date: '.$data."\n";
-			$data = trim($data);
 			if ($data === false || $data === '') return;
-
 			$committime = parseSvnTimestamp($data);
 			$curList->curEntry->committime = $committime;
 			$curList->curEntry->date = date('Y-m-d H:i:s', $committime);
@@ -439,9 +437,7 @@ function logCharacterData($parser, $data) {
 
 		case 'DATE':
 			if ($debugxml) print 'Date: '.$data."\n";
-			$data = trim($data);
 			if ($data === false || $data === '') return;
-
 			$committime = parseSvnTimestamp($data);
 			$curLog->curEntry->committime = $committime;
 			$curLog->curEntry->date = date('Y-m-d H:i:s', $committime);
@@ -457,9 +453,7 @@ function logCharacterData($parser, $data) {
 
 		case 'PATH':
 			if ($debugxml) print 'Path name: '.$data."\n";
-			$data = trim($data);
 			if ($data === false || $data === '') return;
-
 			$curLog->curEntry->curMod->path .= $data;
 			break;
 	}


### PR DESCRIPTION
fgets() and file_get_contents() give us lines with retained line separators. So we need to trim those and *only* those instead of other whitespace chars.

This fixes #181 and closes #183