### PR TITLE
Fix "Call to a member function logsShowChanges() on null" on log.php

### DIFF
--- a/log.php
+++ b/log.php
@@ -32,6 +32,12 @@ $page = (int)@$_REQUEST['page'];
 $all = @$_REQUEST['all'] == 1;
 $isDir = @$_REQUEST['isdir'] == 1 || $path == '' || $path == '/';
 
+// Make sure that we have a repository
+if (!$rep)
+{
+	renderTemplate404('log','NOREP');
+}
+
 if (isset($_REQUEST['showchanges']))
 {
 	$showchanges = @$_REQUEST['showchanges'] == 1;
@@ -93,12 +99,6 @@ if ($dosearch)
 }
 
 $maxperpage = 20;
-
-// Make sure that we have a repository
-if (!$rep)
-{
-	renderTemplate404('log','NOREP');
-}
 
 $svnrep = new SVNRepository($rep);
 


### PR DESCRIPTION
Fixes the following bug:
Call 
.../websvn/log.php?repname=xxx&path=%2F
where xxx is a non-existing repo
Results in Fatal error: Uncaught Error: Call to a member function logsShowChanges() on null in .../log.php:41