### PR TITLE
Fix "Call to a member function isDownloadAllowed() on null" in dl.php

### DIFF
--- a/dl.php
+++ b/dl.php
@@ -54,16 +54,16 @@ function setDirectoryTimestamp($dir, $timestamp) {
 
 // Make sure that downloading the specified file/directory is permitted
 
+if (!$rep)
+{
+	http_response_code(404);
+	exit;
+}
+
 if (!$rep->isDownloadAllowed($path)) {
 	http_response_code(403);
 	error_log('Unable to download resource at path: '.$path);
 	print 'Unable to download resource at path: '.xml_entities($path);
-	exit;
-}
-
-if (!$rep)
-{
-	http_response_code(404);
 	exit;
 }
 


### PR DESCRIPTION
Fixes the following bug:
Calling dl.php?repname=xxx where xxx is a non-existing repo causes the error "Call to a member function isDownloadAllowed() on null" .

Note: I have now verified that all PHP files in the root directory correctly check for "$rep == null" before accessing "$rep->..." . The only problems were filedetails.php (#192) and dl.php (#194) which are now fixed.