### PR TITLE
Attempt to read property ... on null in blame.php (#197)

### DIFF
--- a/blame.php
+++ b/blame.php
@@ -242,7 +242,7 @@ else
 		{
 			$history = $svnrep->getLog($path, $key, $key, false, 1, $peg);
 
-			if ($history) 
+			if ($history && $history->curEntry)
 			{
 				$javascript[] = 'rev['.$key.'] = \'<div class="date">'.$history->curEntry->date.'</div><div class="msg">'.addslashes(preg_replace('/\n/', ' ', $history->curEntry->msg)).'</div>\';';
 			}

--- a/javascript/blame-popup.js
+++ b/javascript/blame-popup.js
@@ -22,10 +22,12 @@ function mouseover(a) {
   // Find the revision number within the hyperlink text
   var m = /rev=(\d+)/.exec(a.href);
   var r = m[1];
-  var div = document.createElement('div');
-  div.className = 'blame-popup';
-  div.innerHTML = rev[r];
-  a.parentNode.appendChild(div);
+  if (rev[r]) {
+    var div = document.createElement('div');
+    div.className = 'blame-popup';
+    div.innerHTML = rev[r];
+    a.parentNode.appendChild(div);
+  }
 }
 
 function mouseout(a) {


### PR DESCRIPTION
Skip entry if the current item does not have a current history entry. This can happen if the item does not exist at the requested peg revision.

This fixes #197