### PR TITLE
New methods have been added to configuration to clear set the encodings of user files.

### DIFF
--- a/include/command.php
+++ b/include/command.php
@@ -23,7 +23,9 @@
 // External command handling
 
 function detectCharacterEncoding($str) {
-	$list = array('UTF-8', 'ISO-8859-1', 'windows-1252');
+	global $config;
+
+	$list = $config->getCharacterEncodings();
 	if (function_exists('mb_detect_encoding')) {
 		foreach ($list as $item) {
 			if (mb_check_encoding($str, $item)) return $item;

--- a/include/configclass.php
+++ b/include/configclass.php
@@ -630,6 +630,7 @@ class WebSvnConfig {
 	var $tar = 'tar';
 	var $zip = 'zip';
 	var $locale = '';
+	var $characterEncodings = array( 'UTF-8', 'ISO-8859-1', 'windows-1252' );
 
 	// different modes for file and directory download
 
@@ -1358,6 +1359,17 @@ class WebSvnConfig {
 
 	function getLocale() {
 		return $this->locale;
+	}
+
+	// setCharacterEncodings
+	//
+	// Set the array of character encodings for user files.
+	function setCharacterEncodings($characterEncodings) {
+		$this->characterEncodings = $characterEncodings;
+	}
+
+	function getCharacterEncodings() {
+		return $this->characterEncodings;
 	}
 
 	// setDefaultFileDlMode

--- a/include/distconfig.php
+++ b/include/distconfig.php
@@ -31,6 +31,9 @@
 // with native commands.
 // $config->setLocale('C.UTF-8');
 
+// Set the array of character encodings for user files.
+// $config->setCharacterEncodings(array( 'UTF-8', 'ISO-8859-1', 'windows-1252' ));
+
 // Configure the path for Subversion to use for --config-dir
 // (e.g. if accepting certificates is required when using repositories via https)
 // $config->setSvnConfigDir('/tmp/websvn');


### PR DESCRIPTION
New methods **setCharacterEncodings(array())** and **getCharacterEncodings()** have been added to configuration.
They allow to set the encodings of user files in a standard way.

For example, for Russian encoding, add the following line to **config.php**:
`$config->setCharacterEncodings(array( 'UTF-8', 'windows-1251' ));`