### PR TITLE
Don't quote commands on Windows anymore (#210)

### DIFF
--- a/include/command.php
+++ b/include/command.php
@@ -122,12 +122,10 @@ function runCommand($cmd, $mayReturnNothing = false, &$errorIf = 'NOT_USED') {
 	$error	= '';
 	$opts	= null;
 
-	// https://github.com/websvnphp/websvn/issues/75
-	// https://github.com/websvnphp/websvn/issues/78
 	if ($config->serverIsWindows) {
 		if (!strpos($cmd, '>') && !strpos($cmd, '|')) {
 			$opts = array('bypass_shell' => true);
-		} else {
+		} else if (PHP_MAJOR_VERSION < 8) {
 			$cmd = '"'.$cmd.'"';
 		}
 	}


### PR DESCRIPTION
With PHP 8.0.0-RC2 the command handling has been simplified and improved. Quoting can be removed since it is now handled properly internally.

See also https://github.com/php/php-src/commit/9ca449e0a803cb9d1d40fd6b83f2da1e6a7b46d9

This fixes #210 and closes #213