### PR TITLE
[fixed] Handle readme.md with lowercase

### DIFF
--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -878,6 +878,11 @@ class SVNRepository {
 
 		if ($this->isFile($path.$file) != True)
 		{
+			$file = "readme.md";
+		}
+
+		if ($this->isFile($path.$file) != True)
+		{
 			return;
 		}
 

--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -870,7 +870,7 @@ class SVNRepository {
 
 	// {{{ listReadmeContents
 	//
-	// Parse the README.md file
+	// Parse the README.md or readme.md file
 	function listReadmeContents($path, $rev = 0, $peg = '') {
 		global $config;
 


### PR DESCRIPTION
Hello WebSVN Developers,

I hope this message finds you well. I've encountered an issue where WebSVN does not correctly parse (lower case) `readme.md` files, causing inconsistencies in rendering Markdown content.

To address this issue and ensure compatibility with different conventions, I've made a small fix to the code. The updated logic now checks for both `README.md` and `readme.md` files, allowing WebSVN to correctly handle Markdown files regardless of case.

I believe this fix will improve the user experience for all WebSVN users and maintain consistency in Markdown file rendering.

Changes:

Updated the file check logic to include both `README.md` and `readme.md`.
I kindly request your review of this pull request. If you have any feedback or suggestions for improvement, please don't hesitate to let me know.

Thank you for your time and consideration.

Best regards,
Robert Abraham