### PR TITLE
Fix rtrim() warning at include/configclass.php:255 on PHP 8.1 and later

### DIFF
--- a/include/configclass.php
+++ b/include/configclass.php
@@ -252,7 +252,7 @@ class Repository {
 		$this->group = $group;
 		$this->username = $username;
 		$this->password = $password;
-		$this->clientRootURL = rtrim($clientRootURL, '/');
+		$this->clientRootURL = $clientRootURL !== null ? rtrim($clientRootURL, '/') : null;
 	}
 
 	// }}}


### PR DESCRIPTION
This PR fixes the warning "Passing null to parameter #1 ($string) of type string is deprecated" shown by include/configclass.php:255 on PHP 8.1 and later.