### PR TITLE
Prevent XSS attack on log.php

### DIFF
--- a/log.php
+++ b/log.php
@@ -500,7 +500,7 @@ if ($config->multiViews)
 else
 {
 	$hidden = '<input type="hidden" name="repname" value="'.$repname.'" />';
-	$hidden .= '<input type="hidden" name="path" value="'.$path.'" />';
+	$hidden .= '<input type="hidden" name="path" value="'.escape($path).'" />';
 }
 
 if ($isDir)


### PR DESCRIPTION
Hi !
I discovered a potentiel vulnerability on websvn/log.php, and here is a PR correcting it.

## How to reproduce
Go to https://site.domain/websvn/log.php?repname=MYREPO&path=%3C/script%3E%27%22%3E%3Cimg%20src=x%20onError=prompt(1)%3E&isdir=1

==> if you see a prompting popup, your site is vulnerable.

My change ensure the "path" variable is escaped before inserting it in DOM