### PR TITLE
Add composer ignore for PKSA-ns3q-qtk3-d35r

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,5 +9,12 @@
         "horde/text_diff": "^3.0.0",
         "erusev/parsedown": "1.7.4"
     },
-    "minimum-stability": "alpha"
+    "minimum-stability": "alpha",
+    "config": {
+        "audit": {
+            "ignore": [
+                "PKSA-ns3q-qtk3-d35r"
+            ]
+        }
+    }
 }


### PR DESCRIPTION
Latest GeSHi has a security issue which is not yet fixed, but it blocks composer from installing. Ignore explicitly.