### PR TITLE
Fix PHP 8.1+ deprecations and remove now-unreachable PHP <8 code paths

### DIFF
--- a/comp.php
+++ b/comp.php
@@ -390,7 +390,7 @@ if (!$noinput)
 				}
 
 				// Check for the start of a new diff area
-				if (!strncmp($line, '@@', 2))
+				if (str_starts_with($line, '@@'))
 				{
 					$pos = strpos($line, '+');
 					$posline = substr($line, $pos);
@@ -447,7 +447,7 @@ if (!$noinput)
 			}
 
 			// Check for a new node entry
-			if (strncmp(trim($line), 'Index: ', 7) == 0)
+			if (str_starts_with(trim($line), 'Index: '))
 			{
 				// End the current node
 				if ($node)
@@ -460,14 +460,14 @@ if (!$noinput)
 				$node = substr($node, 7);
 				if ($node == '' || $node[0] != '/') $node = '/'.$node;
 
-				if (substr($path2, -strlen($node)) === $node)
+				if (str_ends_with($path2, $node))
 				{
 					$absnode = $path2;
 				}
 				else
 				{
 					$absnode = $path2;
-					if (substr($absnode, -1) == '/') $absnode = substr($absnode, 0, -1);
+					if (str_ends_with($absnode, '/')) $absnode = substr($absnode, 0, -1);
 					$absnode .= $node;
 				}
 
@@ -490,7 +490,7 @@ if (!$noinput)
 					$listvar['info'] = $lang['FILEADDED'];
 				}
 
-				if (strncmp(trim($line), 'Cannot display:', 15) == 0)
+				if (str_starts_with(trim($line), 'Cannot display:'))
 				{
 					$index++;
 					clearVars();
@@ -508,7 +508,7 @@ if (!$noinput)
 				continue;
 			}
 
-			if (strncmp(trim($line), 'Property changes on: ', 21) == 0)
+			if (str_starts_with(trim($line), 'Property changes on: '))
 			{
 				$propnode = trim($line);
 				$propnode = substr($propnode, 21);
@@ -539,11 +539,11 @@ if (!$noinput)
 
 				while ($line = rtrim(fgets($diff), "\n\r"))
 				{
-					if (!strncmp(trim($line), 'Index: ', 7))
+					if (str_starts_with(trim($line), 'Index: '))
 					{
 						break;
 					}
-					if (!strncmp(trim($line), '##', 2) || $line == '\ No newline at end of file')
+					if (str_starts_with(trim($line), '##') || $line == '\ No newline at end of file')
 					{
 						continue;
 					}
@@ -556,7 +556,7 @@ if (!$noinput)
 			}
 
 			// Check for error messages
-			if (strncmp(trim($line), 'svn: ', 5) == 0)
+			if (str_starts_with(trim($line), 'svn: '))
 			{
 				$listing[$index++]['info'] = urldecode($line);
 				$vars['success'] = false;

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,10 @@
     "keywords": ["subversion", "svn", "websvn"],
     "type": "project",
     "require": {
+        "php": "^8.0",
         "geshi/geshi": "^1.0.9.1",
         "pear/archive_tar": "^1.4.14",
-        "horde/text_diff": "^3.0.0",
+        "horde/text_diff": "3.0.0alpha4",
         "erusev/parsedown": "1.7.4"
     },
     "minimum-stability": "alpha",

--- a/dl.php
+++ b/dl.php
@@ -106,7 +106,7 @@ $tempDir = tempnamWithCheck($config->getTempDir(), 'websvn');
 mkdir($tempDir);
 // Create the name of the directory being archived
 $archiveName = $path;
-$isDir = (substr($archiveName, -1) == '/');
+$isDir = str_ends_with($archiveName, '/');
 
 if ($isDir)
 {
@@ -177,7 +177,7 @@ if (!empty($_REQUEST['dlmode']))
 {
 	$downloadMode = $_REQUEST['dlmode'];
 
-	if (substr($logEntry->path, -1) == '/')
+	if (str_ends_with($logEntry->path, '/'))
 	{
 		if (!in_array($downloadMode, $config->validDirectoryDlModes))
 		{

--- a/include/bugtraq.php
+++ b/include/bugtraq.php
@@ -75,8 +75,8 @@ class Bugtraq {
 				}
 			}
 
-			$this->msgstring = trim(@$this->msgstring);
-			$this->urlstring = trim(@$this->urlstring);
+			$this->msgstring = trim($this->msgstring ?? '');
+			$this->urlstring = trim($this->urlstring ?? '');
 
 			if ($enoughdata && !empty($this->msgstring)) {
 				$this->initPartInfo();

--- a/include/command.php
+++ b/include/command.php
@@ -65,7 +65,17 @@ function toOutputEncoding($str) {
 			|  \xF4[\x80-\x8F][\x80-\xBF]{2}     # plane 16
 			)*$%xs', $str
 		);
-		if (!$isUtf8) $str = utf8_encode($str);
+		if (!$isUtf8) {
+			// Neither mbstring nor iconv is available: fall back to a manual
+			// ISO-8859-1/Latin-1 to UTF-8 conversion (utf8_encode() is
+			// deprecated as of PHP 8.2 and removed in PHP 9.0).
+			$out = '';
+			foreach (str_split($str) as $c) {
+				$o = ord($c);
+				$out .= ($o < 0x80) ? $c : (chr(0xC0 | ($o >> 6)).chr(0x80 | ($o & 0x3F)));
+			}
+			$str = $out;
+		}
 	}
 
 	return $str;
@@ -125,8 +135,6 @@ function runCommand($cmd, $mayReturnNothing = false, &$errorIf = 'NOT_USED') {
 	if ($config->serverIsWindows) {
 		if (!strpos($cmd, '>') && !strpos($cmd, '|')) {
 			$opts = array('bypass_shell' => true);
-		} else if (PHP_MAJOR_VERSION < 8) {
-			$cmd = '"'.$cmd.'"';
 		}
 	}
 

--- a/include/configclass.php
+++ b/include/configclass.php
@@ -1092,7 +1092,7 @@ class WebSvnConfig {
 
 	function findException($path, $exceptions) {
 		foreach ($exceptions as $key => $exc) {
-			if (strncmp($exc, $path, strlen($exc)) == 0) {
+			if (str_starts_with($path, $exc)) {
 				return true;
 			}
 		}
@@ -1135,7 +1135,7 @@ class WebSvnConfig {
 				$path = '/'.$path;
 			}
 
-			if (substr($url, -5) == 'index') {
+			if (str_ends_with($url, 'index')) {
 				$url = substr($url, 0, -5).$this->multiViewsIndex;
 			}
 

--- a/include/diff_inc.php
+++ b/include/diff_inc.php
@@ -170,7 +170,7 @@ function diff_result($all, $highlighted, $newtname, $oldtname, $obj, $ignoreWhit
 		$fin = false;
 		while (!endOfFile($obj) && !$fin) {
 			$line = nextLine($obj);
-			if ($line === false || $line === '' || strncmp($line, '@@', 2) == 0) {
+			if ($line === false || $line === '' || str_starts_with($line, '@@')) {
 				$sensibleLineChanges->addChangesToListing($listingHelper, $highlighted);
 				$fin = true;
 			} else {
@@ -295,12 +295,6 @@ function inline_diff($all, $ignoreWhitespace, $highlighted, $newtname, $oldtname
 		$context = 1;
 	}
 
-	// modify error reporting level to suppress deprecated/strict warning "Assigning the return value of new by reference"
-	$bckLevel = error_reporting();
-	$removeLevel = E_DEPRECATED;
-	$modLevel = $bckLevel & (~$removeLevel);
-	error_reporting($modLevel);
-
 	// Create the diff class
 	$fromLines = file($oldtname);
 	$toLines = file($newtname);
@@ -324,9 +318,6 @@ function inline_diff($all, $ignoreWhitespace, $highlighted, $newtname, $oldtname
 	}
 	$renderer = new Horde_Text_Diff_Renderer_Unified(array('leading_context_lines' => $context, 'trailing_context_lines' => $context));
 	$rendered = explode("\n", $renderer->render($diff));
-
-	// restore previous error reporting level
-	error_reporting($bckLevel);
 
 	$arrayBased = true;
 	$fileBased = false;

--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -533,11 +533,11 @@ function encodePath($uri) {
 
 	// Correct for Window share names
 	if ($config->serverIsWindows) {
-		if (substr($uri, 0, 2) == '//') {
+		if (str_starts_with($uri, '//')) {
 			$uri = '\\'.substr($uri, 2, strlen($uri));
 		}
 
-		if (substr($uri, 0, 10) == 'file://///' ) {
+		if (str_starts_with($uri, 'file://///')) {
 			$uri = 'file:///\\'.substr($uri, 10, strlen($uri));
 		}
 	}
@@ -1198,7 +1198,7 @@ class SVNRepository {
 						$pos = strrpos($modpath, '/');
 						$modpath = substr($modpath, 0, $pos + 1);
 					}
-					if (strlen($modpath) == 0 || substr($modpath, -1) !== '/') {
+					if (strlen($modpath) == 0 || !str_ends_with($modpath, '/')) {
 						$modpath .= '/';
 					}
 					//compare with current precise path
@@ -1206,7 +1206,7 @@ class SVNRepository {
 						$precisePath = $modpath;
 					} else {
 						$equalPart = _equalPart($precisePath, $modpath);
-						if (substr($equalPart, -1) !== '/') {
+						if (!str_ends_with($equalPart, '/')) {
 							$pos = strrpos($equalPart, '/');
 							$equalPart = substr($equalPart, 0, $pos + 1);
 						}

--- a/include/template.php
+++ b/include/template.php
@@ -41,7 +41,7 @@ function parseCommand($line, $vars, $handle) {
 	global $ignore, $ignorestack, $ignorelevel, $config, $listing, $vars;
 
 	// process content of included file
-	if (strncmp(trim($line), '[websvn-include:', 16) == 0) {
+	if (str_starts_with(trim($line), '[websvn-include:')) {
 		if (!$ignore) {
 			$line = trim($line);
 			$file = substr($line, 16, -1);
@@ -52,7 +52,7 @@ function parseCommand($line, $vars, $handle) {
 
 
 	// Check for test conditions
-	if (strncmp(trim($line), '[websvn-test:', 13) == 0) {
+	if (str_starts_with(trim($line), '[websvn-test:')) {
 		if (!$ignore) {
 			$line = trim($line);
 			$var = substr($line, 13, -1);
@@ -68,14 +68,14 @@ function parseCommand($line, $vars, $handle) {
 		return true;
 	}
 
-	if (strncmp(trim($line), '[websvn-else]', 13) == 0) {
+	if (str_starts_with(trim($line), '[websvn-else]')) {
 		if ($ignorelevel == 0) {
 			$ignore = !$ignore;
 		}
 		return true;
 	}
 
-	if (strncmp(trim($line), '[websvn-endtest]', 16) == 0) {
+	if (str_starts_with(trim($line), '[websvn-endtest]')) {
 		if ($ignorelevel > 0) {
 			$ignorelevel--;
 		} else {
@@ -84,7 +84,7 @@ function parseCommand($line, $vars, $handle) {
 		return true;
 	}
 
-	if (strncmp(trim($line), '[websvn-getlisting]', 19) == 0) {
+	if (str_starts_with(trim($line), '[websvn-getlisting]')) {
 		global $svnrep, $path, $rev, $peg;
 
 		if (!$ignore) {
@@ -118,7 +118,7 @@ function parseCommand($line, $vars, $handle) {
 		return true;
 	}
 
-	if (strncmp(trim($line), '[websvn-icon]', 13) == 0) {
+	if (str_starts_with(trim($line), '[websvn-icon]')) {
 		global $icons, $vars;
 
 		if (!$ignore) {
@@ -133,7 +133,7 @@ function parseCommand($line, $vars, $handle) {
 		return true;
 	}
 
-	if (strncmp(trim($line), '[websvn-treenode]', 17) == 0) {
+	if (str_starts_with(trim($line), '[websvn-treenode]')) {
 		global $icons, $vars;
 
 		if (!$ignore) {
@@ -206,7 +206,7 @@ function parseTemplate($file) {
 			continue;
 		} else {
 			// Check for the start of the file list
-			if (strncmp(trim($line), '[websvn-startlisting]', 21) == 0) {
+			if (str_starts_with(trim($line), '[websvn-startlisting]')) {
 				$inListing = true;
 			} else {
 				if ($ignore == false) {

--- a/listing.php
+++ b/listing.php
@@ -103,8 +103,8 @@ function showDirFiles($svnrep, $subs, $level, $limit, $rev, $peg, $listing, $ind
 			$listvar['revision'] = $rev;
 			$listvar['revurl'] = $config->getURL($rep, $parentPath, 'revision').'rev='.$rev.'&amp;isdir=1';
 			global $vars;
-			$listvar['date'] = $vars['date'];
-			$listvar['age'] = datetimeFormatDuration(time() - strtotime($vars['date']), true, true);
+			$listvar['date'] = $vars['date'] ?? '';
+			$listvar['age'] = $listvar['date'] ? datetimeFormatDuration(time() - strtotime($listvar['date']), true, true) : '';
 			$index++;
 		}
 	}
@@ -227,7 +227,7 @@ function showDirFiles($svnrep, $subs, $level, $limit, $rev, $peg, $listing, $ind
 		if ($isDir && ($level != $limit))
 		{
 			// @todo remove the alternate check with htmlentities when assured that there are not side effects
-			if (isset($subs[$level + 1]) && (!strcmp($subs[$level + 1].'/', $file) || !strcmp(htmlentities($subs[$level + 1], ENT_QUOTES).'/', htmlentities($file))))
+			if (isset($subs[$level + 1]) && (!strcmp($subs[$level + 1].'/', $file) || !strcmp(htmlentities($subs[$level + 1], ENT_QUOTES).'/', htmlentities($file, ENT_QUOTES))))
 			{
 				$listing = showDirFiles($svnrep, $subs, $level + 1, $limit, $rev, $peg, $listing, $index);
 				$index = count($listing);
@@ -274,8 +274,8 @@ function showAllDirFiles($svnrep, $path, $rev, $peg, $listing, $index, $treeView
 			$listvar['revision'] = $rev;
 			$listvar['revurl'] = $config->getURL($rep, $parentPath, 'revision').'rev='.$rev.'&amp;isdir=1';
 			global $vars;
-			$listvar['date'] = $vars['date'];
-			$listvar['age'] = datetimeFormatDuration(time() - strtotime($vars['date']), true, true);
+			$listvar['date'] = $vars['date'] ?? '';
+			$listvar['age'] = $listvar['date'] ? datetimeFormatDuration(time() - strtotime($listvar['date']), true, true) : '';
 			$index++;
 		}
 	}


### PR DESCRIPTION
Keep PHP 8.0 as the floor while eliminating deprecation warnings and version-dependent branches that newer 8.x releases would otherwise flag:

- Declare "php": "^8.0" in composer.json as the explicit minimum
- Replace utf8_encode() (deprecated 8.2, removed 9.0) with a manual Latin-1 to UTF-8 fallback in toOutputEncoding()
- Guard against passing null to strtotime()/trim() where a value may be unset (listing.php date/age, Bugtraq msgstring/urlstring)
- Make both htmlentities() calls in listing.php pass ENT_QUOTES explicitly so the comparison no longer depends on PHP's default flags
- Drop the PHP_MAJOR_VERSION < 8 Windows quoting branch in runCommand(), dead now that 8.0 is the floor (fixed upstream in PHP 8.0.0-RC2)
- Remove the vestigial E_DEPRECATED suppression around Horde_Text_Diff construction, a leftover PHP 5-era guard for syntax this code never used
- Pin horde/text_diff to 3.0.0alpha4; the stable 3.0.0 tag now requires php ^8.1, which would break composer install on the 8.0 baseline
- Replace strncmp()/substr() start/end checks with str_starts_with()/ str_ends_with() (PHP 8.0+) across comp.php, listing template parsing, svnlook.php, and configclass.php