### PR TITLE
Clamp negative rev/peg request parameters to 0

### DIFF
--- a/include/setup.php
+++ b/include/setup.php
@@ -500,8 +500,8 @@ if ($path === null || $path === '')
 $vars['path'] = str_replace('%2F', '/', rawurlencode($path));
 $vars['safepath'] = escape($path);
 // Set operative and peg revisions (if specified) and save passed-in revision
-$rev = (int)@$_REQUEST['rev'];
-$peg = (int)@$_REQUEST['peg'];
+$rev = max(0, (int)@$_REQUEST['rev']);
+$peg = max(0, (int)@$_REQUEST['peg']);
 $search = (string)@$_REQUEST['search'];
 if ($peg === 0)
 	$peg = '';


### PR DESCRIPTION
A negative "rev" (e.g. rev=-1) passed empty() unnoticed since PHP only treats 0, '', and null as empty, not -1. The value then flowed into svn log's -r range argument (e.g. "-r -1:1"), which svn rejects as a syntax error, filling php_error.log even though the page still correctly rendered a 404.

Clamping at the single point where rev/peg are parsed from the request routes bogus negative input into the existing "not specified" fallback (0) used throughout the app, instead of letting it reach shell commands.

Fixes #191