### PR TITLE
Close remaining XSS gaps missed by d4de770 (#228)

### DIFF
--- a/comp.php
+++ b/comp.php
@@ -131,7 +131,7 @@ if ($config->multiViews)
 }
 else
 {
-	$hidden .= '<input type="hidden" name="repname" value="'.$repname.'" />';
+	$hidden .= '<input type="hidden" name="repname" value="'.escape($repname).'" />';
 }
 
 $vars['compare_form'] = '<form method="get" action="'.$url.'" id="compare">'.$hidden;

--- a/listing.php
+++ b/listing.php
@@ -621,7 +621,7 @@ if ($config->multiViews)
 }
 else
 {
-	$vars['compare_form'] .= '<input type="hidden" name="repname" value="'.$repname.'" />';
+	$vars['compare_form'] .= '<input type="hidden" name="repname" value="'.escape($repname).'" />';
 }
 
 $vars['compare_submit'] = '<input type="submit" value="'.$lang['COMPAREPATHS'].'" />';

--- a/log.php
+++ b/log.php
@@ -425,7 +425,7 @@ if (!empty($history))
 		if (!$numSearchResults)
 		{
 			$url = $config->getURL($rep, $path, 'log').$isDirString.$thisRevString;
-			$vars['logsearch_moreresultslink'] = '<a href="'.$url.'&amp;search='.$search.'&amp;fr='.$thisrev.'">'.$lang['MORERESULTS'].'</a>';
+			$vars['logsearch_moreresultslink'] = '<a href="'.$url.'&amp;search='.rawurlencode($search).'&amp;fr='.$thisrev.'">'.$lang['MORERESULTS'].'</a>';
 			break;
 		}
 	}
@@ -499,7 +499,7 @@ if ($config->multiViews)
 }
 else
 {
-	$hidden = '<input type="hidden" name="repname" value="'.$repname.'" />';
+	$hidden = '<input type="hidden" name="repname" value="'.escape($repname).'" />';
 	$hidden .= '<input type="hidden" name="path" value="'.escape($path).'" />';
 }
 
@@ -519,8 +519,8 @@ if ($showchanges != $rep->logsShowChanges())
 }
 
 $vars['logsearch_form'] = '<form method="get" action="'.$config->getURL($rep, $path, 'log').'" id="search">'.$hidden;
-$vars['logsearch_startbox'] = '<input name="sr" size="5" value="'.$startrev.'" />';
-$vars['logsearch_endbox'] = '<input name="er" size="5" value="'.$endrev.'" />';
+$vars['logsearch_startbox'] = '<input name="sr" size="5" value="'.escape($startrev).'" />';
+$vars['logsearch_endbox'] = '<input name="er" size="5" value="'.escape($endrev).'" />';
 $vars['logsearch_maxbox'] = '<input name="max" size="5" value="'.($max == 0 ? 40 : $max).'" />';
 $vars['logsearch_inputbox'] = '<input name="search" value="'.escape($search).'" />';
 $vars['logsearch_showall'] = '<input type="checkbox" name="all" value="1"'.($all ? ' checked="checked"' : '').' />';
@@ -543,7 +543,7 @@ if ($config->multiViews)
 }
 else
 {
-	$vars['compare_form'] .= '<input type="hidden" name="repname" value="'.$repname.'" />';
+	$vars['compare_form'] .= '<input type="hidden" name="repname" value="'.escape($repname).'" />';
 }
 
 $vars['compare_submit'] = '<input type="submit" value="'.$lang['COMPAREREVS'].'" />';

--- a/search.php
+++ b/search.php
@@ -362,7 +362,7 @@ if ($config->multiViews)
 }
 else
 {
-	$vars['compare_form'] .= '<input type="hidden" name="repname" value="'.$repname.'" />';
+	$vars['compare_form'] .= '<input type="hidden" name="repname" value="'.escape($repname).'" />';
 }
 
 $vars['compare_submit'] = '<input type="submit" value="'.$lang['COMPAREPATHS'].'" />';


### PR DESCRIPTION
d4de770 escaped $rev/$search only in the search/revision selection forms in include/setup.php. Two more unescaped sinks remained:

- log.php's "more results" link concatenated raw $search into a URL query string inside an href attribute; rawurlencode() it like other query values in the codebase (e.g. revision.php's compare links).
- log.php's start/end revision search boxes echoed $startrev/$endrev (raw request input) directly into value attributes.

Also fixes a related, previously unreported gap: the hidden "repname" input, built from the unsanitized $_REQUEST['repname'] in include/setup.php, was emitted unescaped in comp.php, listing.php, log.php (x2), and search.php.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

This fixes #228