### PR TITLE
Remove Parsedown-based README rendering feature

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,7 @@
         "php": "^8.0",
         "geshi/geshi": "^1.0.9.1",
         "pear/archive_tar": "^1.4.14",
-        "horde/text_diff": "3.0.0alpha4",
-        "erusev/parsedown": "1.7.4"
+        "horde/text_diff": "3.0.0alpha4"
     },
     "minimum-stability": "alpha",
     "config": {

--- a/include/configclass.php
+++ b/include/configclass.php
@@ -662,8 +662,6 @@ class WebSvnConfig {
 	var $useEnscriptBefore_1_6_3 = false;
 	var $useGeshi = false;
 	var $geshiScript = 'geshi.php';
-	var $useParsedown = false;
-	var $parsedownScript = 'Parsedown.php';
 	var $inlineMimeTypes = array();
 	var $allowDownload = false;
 	var $tempDir = '';
@@ -889,29 +887,6 @@ class WebSvnConfig {
 
 	function getUseGeshi() {
 		return $this->useGeshi;
-	}
-
-	// }}}
-
-	// {{{ Parsedown
-
-	function setParsedownPath($path) {
-		$this->_setPath($this->parsedownScript, $path, 'Parsedown.php');
-	}
-
-	function getParsedownScript() {
-		return $this->parsedownScript;
-	}
-
-	// useParsedown
-	//
-	// Use Parsedown to render README.md or readme.md
-	function useParsedown() {
-		$this->useParsedown = true;
-	}
-
-	function getUseParsedown() {
-		return $this->useParsedown;
 	}
 
 	// }}}

--- a/include/distconfig.php
+++ b/include/distconfig.php
@@ -427,18 +427,6 @@ $config->setMinDownloadLevel(2);
 
 // }}}
 
-// {{{ Markdown Render
-
-// Uncomment this line if you want to enable Markdown Rendering of README.md or readme.md file in the path.
-// You will need the Parsedown.php (https://github.com/erusev/parsedown) library for this to work.
-// This will look for README.md or readme.md file on the path and render it.
-// The name of README file isn't configurable for now to simply follow GitHub's conventions.
-
-// $config->useParsedown();
-// $config->setParsedownPath('/usr/share/php/Parsedown/'); // optional. Use if you have Parsedown installed without PEAR/Composer
-
-// }}}
-
 // {{{ RSSFEED ---
 
 // Uncomment this line to hide the RSS feed links across all repositories

--- a/include/svnlook.php
+++ b/include/svnlook.php
@@ -876,55 +876,6 @@ class SVNRepository {
 
 	// }}}
 
-	// {{{ listReadmeContents
-	//
-	// Parse the README.md or readme.md file
-	function listReadmeContents($path, $rev = 0, $peg = '') {
-		global $config;
-
-		$file = "README.md";
-
-		if ($this->isFile($path.$file) != True)
-		{
-			$file = "readme.md";
-		}
-
-		if ($this->isFile($path.$file) != True)
-		{
-			return;
-		}
-
-		if (!$config->getUseParsedown())
-		{
-			return;
-		}
-
-		// Autoloader handles most of the time
-		if (!defined('USE_AUTOLOADER')) {
-			require_once $config->getParsedownScript();
-		}
-
-		$mdParser = new Parsedown();
-		$cmd = $this->svnCommandString('cat', $path.$file, $rev, $peg);
-
-		if (!($result = popenCommand($cmd, 'r')))
-		{
-			return;
-		}
-
-		echo('<div id="wrap">');
-		while (!feof($result))
-		{
-			$line = fgets($result, 1024);
-			echo $mdParser->text($line);
-		}
-		echo('</div>');
-		pclose($result);
-
-	}
-
-	// }}}
-
 	// {{{ getBlameDetails
 	//
 	// Dump the blame content of a file to the given filename

--- a/include/template.php
+++ b/include/template.php
@@ -263,7 +263,7 @@ function parseTags($line, $vars) {
 //
 // Renders the templates for the given view
 
-function renderTemplate($view, $readmePath = null)
+function renderTemplate($view)
 {
 
 	global $config, $rep, $vars, $listing, $lang, $locwebsvnhttp;
@@ -291,14 +291,6 @@ function renderTemplate($view, $readmePath = null)
 			print '<script type="text/javascript" src="'.$locwebsvnhttp.'/javascript/compare-checkboxes.js"></script>';
 		}
 
-		if ($readmePath == null)
-		{
-			parseTemplate('footer.tmpl');
-			return;
-		}
-
-		$svnrep = new SVNRepository($rep);
-		$svnrep->listReadmeContents($readmePath);
 		parseTemplate('footer.tmpl');
 	}
 }

--- a/listing.php
+++ b/listing.php
@@ -639,4 +639,4 @@ if (!$rep->hasReadAccess($path))
 }
 
 $vars['restricted'] = !$rep->hasReadAccess($path, false);
-renderTemplate('directory', $path);
+renderTemplate('directory');


### PR DESCRIPTION
The feature was opt-in, off by default, and had an unfixed layout bug
open since 2022 (#174): listReadmeContents() hardcoded a <div id="wrap">
in include/svnlook.php that collides with the calm template's own #wrap container and renders outside Elegant's #content entirely, since template markup shouldn't live in the PHP logic layer to begin with.

More importantly, erusev/parsedown 2.0 is a ground-up rewrite (PSR-4 namespaced classes under Erusev\Parsedown\, no top-level Parsedown class, requires ext-mbstring) incompatible with this integration's direct `new Parsedown()` usage and flat-file autoloading. Staying on 1.7.4 means riding an increasingly unmaintained branch; moving to 2.x means rewriting the integration for a narrow, rarely-used feature.

Removes:
- erusev/parsedown dependency from composer.json
- WebSvnConfig::useParsedown()/getUseParsedown()/setParsedownPath()/ getParsedownScript() and their backing properties
- SVNRepository::listReadmeContents()
- the $readmePath parameter and its handling in renderTemplate()
- the corresponding doc block in include/distconfig.php

The layout bug is not fixed; the feature that had it is gone.

Closes #174
Closes #204 (feature request to extend a feature that no longer exists)