### PR TITLE
Add setAuthzUsernameCase() to mirror mod_authz_svn's case folding (#56)

### DIFF
--- a/include/authz.php
+++ b/include/authz.php
@@ -48,12 +48,25 @@ class Authorization {
 	// Set the username from the current http session
 
 	function setUsername() {
+		global $config;
+
 		if (isset($_SERVER['REMOTE_USER'])) {
 			$this->user = $_SERVER['REMOTE_USER'];
 		} else if (isset($_SERVER['REDIRECT_REMOTE_USER'])) {
 			$this->user = $_SERVER['REDIRECT_REMOTE_USER'];
 		} else if (isset($_SERVER['PHP_AUTH_USER'])) {
 			$this->user = $_SERVER['PHP_AUTH_USER'];
+		}
+
+		if ($this->user !== null) {
+			switch ($config->getAuthzUsernameCase()) {
+				case 'upper':
+					$this->user = strtoupper($this->user);
+					break;
+				case 'lower':
+					$this->user = strtolower($this->user);
+					break;
+			}
 		}
 	}
 

--- a/include/configclass.php
+++ b/include/configclass.php
@@ -676,6 +676,8 @@ class WebSvnConfig {
 	var $bugtraq = false;
 	var $bugtraqProperties = null;
 	var $authz = null;
+	var $authzUsernameCase = null;
+	var $validAuthzUsernameCases = array( 'upper', 'lower' );
 	var $blockRobots = false;
 
 	var $loadAllRepos = false;
@@ -1537,6 +1539,24 @@ class WebSvnConfig {
 			$repo =& $this->findRepository($myrep);
 			$repo->useAccessFile($file);
 		}
+	}
+
+	// mod_authz_svn's "AuthzForceUsernameCase" folds the username's case before checking it against
+	// the authz file, but only for its own authorization decision: it never touches the underlying
+	// REMOTE_USER value, so WebSVN (running as a separate script) always sees the unconverted
+	// username and has no way to detect that mod_authz_svn is folding case for its own purposes.
+	// Set to 'upper' or 'lower' to apply the equivalent conversion before WebSVN checks access itself.
+	function setAuthzUsernameCase($case) {
+		if (in_array($case, $this->validAuthzUsernameCases)) {
+			$this->authzUsernameCase = $case;
+		} else {
+			echo 'Setting authz username case to an invalid value "'.$case.'"';
+			exit;
+		}
+	}
+
+	function getAuthzUsernameCase() {
+		return $this->authzUsernameCase;
 	}
 
 	function &getAuthz() {

--- a/include/distconfig.php
+++ b/include/distconfig.php
@@ -263,6 +263,16 @@ $config->addTemplatePath($locwebsvnreal.'/templates/Elegant/');
 
 // $config->useAccessFile('/path/to/accessfile', 'myrep'); // Access file for myrep
 
+// If your Subversion setup uses mod_authz_svn's "AuthzForceUsernameCase" directive to fold the
+// authenticated username's case before checking it against the access file, uncomment one of the
+// following lines to apply the same conversion in WebSVN. mod_authz_svn only folds the case for
+// its own authorization decision; the username WebSVN receives (e.g. via REMOTE_USER) is always
+// unconverted, so without this WebSVN's access checks won't match entries in an access file that
+// assumes case-folded usernames.
+
+// $config->setAuthzUsernameCase('lower');
+// $config->setAuthzUsernameCase('upper');
+
 // Uncomment this line if you want to prevent search bots to index the WebSVN pages.
 
 // $config->setBlockRobots();


### PR DESCRIPTION
mod_authz_svn's AuthzForceUsernameCase directive folds the authenticated username's case before checking it against the authz file, but only for its own authorization decision inside Apache. Confirmed in Subversion's own source (get_username_to_authorize() in mod_authz_svn.c): it copies r->user into a new buffer before converting case, leaving the original untouched. That means REMOTE_USER as seen by any other application, WebSVN included, is always the pre-conversion value, with no way to detect that Apache is folding case at all.

Since WebSVN shells out to svnauthz for access checks, and svnauthz performs the same case-sensitive matching against the authz file that mod_authz_svn's underlying svn_repos_authz_check_access() does, a mismatch in username case between what WebSVN passes and what the authz file expects silently denies access that Subversion itself would grant.

Add $config->setAuthzUsernameCase('upper'|'lower') to apply the same conversion WebSVN-side, in Authorization::setUsername(), before the username is used for any access check.

Fixes #56