### PR TITLE
Rename useAccessFile() to setAccessFile(), deprecate old name

### DIFF
--- a/include/configclass.php
+++ b/include/configclass.php
@@ -540,7 +540,13 @@ class Repository {
 
 	// {{{ Authorization
 
+	// Deprecated alias for setAccessFile(), kept for backwards compatibility.
 	function useAccessFile($file) {
+		trigger_error('useAccessFile() is deprecated, use setAccessFile() instead', E_USER_DEPRECATED);
+		$this->setAccessFile($file);
+	}
+
+	function setAccessFile($file) {
 		if (is_readable($file)) {
 			if ($this->authz === null) {
 				$this->authz = new Authorization();
@@ -1524,7 +1530,13 @@ class WebSvnConfig {
 		return $this->ignoreWebSVNContentTypes;
 	}
 
+	// Deprecated alias for setAccessFile(), kept for backwards compatibility.
 	function useAccessFile($file, $myrep = 0) {
+		trigger_error('useAccessFile() is deprecated, use setAccessFile() instead', E_USER_DEPRECATED);
+		$this->setAccessFile($file, $myrep);
+	}
+
+	function setAccessFile($file, $myrep = 0) {
 		if (empty($myrep)) {
 			if (is_readable($file)) {
 				if ($this->authz === null) {
@@ -1537,7 +1549,7 @@ class WebSvnConfig {
 			}
 		} else {
 			$repo =& $this->findRepository($myrep);
-			$repo->useAccessFile($file);
+			$repo->setAccessFile($file);
 		}
 	}
 

--- a/include/distconfig.php
+++ b/include/distconfig.php
@@ -256,12 +256,12 @@ $config->addTemplatePath($locwebsvnreal.'/templates/Elegant/');
 // to the WebSVN (or browse) directory as you have for Subversion itself. More information can be
 // found in install.txt
 
-// $config->useAccessFile('/path/to/accessfile'); // Global access file
+// $config->setAccessFile('/path/to/accessfile'); // Global access file
 
 // You may also specify a per repository access file by uncommenting and copying the following
 // line as necessary. Use the convention 'groupname.myrep' if your repository is in a group.
 
-// $config->useAccessFile('/path/to/accessfile', 'myrep'); // Access file for myrep
+// $config->setAccessFile('/path/to/accessfile', 'myrep'); // Access file for myrep
 
 // If your Subversion setup uses mod_authz_svn's "AuthzForceUsernameCase" directive to fold the
 // authenticated username's case before checking it against the access file, uncomment one of the


### PR DESCRIPTION
useAccessFile() only ever assigns a single access-file path, the same shape as every other setXxxPath()-style setter in this class (e.g. setSvnCommandPath(), setDiffPath(), setTempDir()). The "use" prefix is reserved elsewhere for toggling a feature/mode on (useMultiViews(), useTreeView(), useGeshi()), which useAccessFile() never did -- the name is a holdover from the pre-svnauthz auth.php days and doesn't match this class's own naming convention.

Introduce setAccessFile() (both the global WebSvnConfig variant and the per-repository Repository variant) as the correctly-named entry point. useAccessFile() becomes a deprecated alias that emits E_USER_DEPRECATED before delegating, so existing config.php files keep working unchanged. Internal call sites and the shipped example config now use the new name directly.

No behavior change: this is a pure rename plus a deprecation notice.