### PR TITLE
Don't toggle collapsible diff when clicking its file-name link

### DIFF
--- a/javascript/collapsible.js
+++ b/javascript/collapsible.js
@@ -29,8 +29,13 @@ function collapseAllGroups()
     }
 }
 
-$("table.collapsible thead").find("th").on("click", function()
+$("table.collapsible thead").find("th").on("click", function(e)
 {
+    if ($(e.target).closest("a").length)
+    {
+        return; // let the link navigate; don't toggle the diff too
+    }
+
     let oldClass = $(this).get(0).className;
     let newClass = (oldClass == 'open') ? 'closed' : 'open';
 


### PR DESCRIPTION
The click handler was bound to the whole <th> header cell, but that cell also contains an <a> linking to the file itself. Since link clicks bubble up to their parent <th>, clicking the file name both navigated to the file and toggled the diff's visibility at the same time.

Skip the toggle when the click originated on (or inside) a link, so the link's default navigation is the only thing that happens.